### PR TITLE
Fix for cases where one input variable is used.

### DIFF
--- a/SALib/analyze/extended_fast.py
+++ b/SALib/analyze/extended_fast.py
@@ -9,6 +9,9 @@ def analyze(pfile, output_file, column = 0, M = 4, num_resamples = 1000, delim =
     
     param_file = read_param_file(pfile)
     Y = np.loadtxt(output_file, delimiter = delim)
+
+    if len(Y.shape) == 1: Y = Y.reshape((len(Y),1))
+
     D = param_file['num_vars']
     
     if Y.ndim > 1:

--- a/SALib/analyze/morris.py
+++ b/SALib/analyze/morris.py
@@ -9,6 +9,9 @@ def analyze(pfile, input_file, output_file, column = 0, delim = ' ', num_resampl
     param_file = read_param_file(pfile)
     Y = np.loadtxt(output_file, delimiter = delim)
     X = np.loadtxt(input_file, delimiter = delim)
+
+    if len(Y.shape) == 1: Y = Y.reshape((len(Y),1))
+    if len(X.shape) == 1: X = X.reshape((len(X),1))
     
     if Y.ndim > 1:
         Y = Y[:, column]

--- a/SALib/analyze/sobol.py
+++ b/SALib/analyze/sobol.py
@@ -9,6 +9,8 @@ def analyze(pfile, output_file, column = 0, calc_second_order = True, num_resamp
     
     param_file = read_param_file(pfile)
     Y = np.loadtxt(output_file, delimiter = delim)
+
+    if len(Y.shape) == 1: Y = Y.reshape((len(Y),1))
     
     if Y.ndim > 1:
         Y = Y[:, column]


### PR DESCRIPTION
If there is only one input variable, files will be single column.  Numpy
reads these as row array rather than as a column array, so they need to be
converted.
