### PR TITLE
simple regression test for parallel sobol

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,10 @@
 ###Contributing
 
-Thanks to all those who contributed so far, including: [Will Usher](https://github.com/willu47), [Chris Mutel](https://github.com/cmutel), [Matt Woodruff](https://github.com/matthewjwoodruff), [Fernando Rios](https://github.com/zoidy), and [Dan Hyams](https://github.com/dhyams), [xantares](https://github.com/xantares). The library would be in much worse shape without these efforts.
+Admins: [Will Usher](https://github.com/willu47) and [Jon Herman](https://github.com/jdherman)
 
-In my view, development should follow a few objectives:
+Thanks to all those who contributed so far, including: [Chris Mutel](https://github.com/cmutel), [Bernardo Trindade](https://github.com/bernardoct), [Dave Hadka](https://github.com/dhadka), [Matt Woodruff](https://github.com/matthewjwoodruff), [Fernando Rios](https://github.com/zoidy), and [Dan Hyams](https://github.com/dhyams), [xantares](https://github.com/xantares). The library would be in much worse shape without these efforts.
+
+Development should follow a few objectives:
 
 * Maintain the decoupled sample/analysis workflow, including the command-line interface. People may not have their models written in Python, so the ability to work from data files rather than Python objects is important. Sending parameter samples to the model should be left to the user.
 

--- a/README-advanced.md
+++ b/README-advanced.md
@@ -34,4 +34,10 @@ python -m SALib.analyze.sobol \
 
 This will print indices and confidence intervals to the command line. You can redirect to a file using the `>` operator.
 
+#### Parallel indices calculation (Sobol method only)
+```python
+Si = sobol.analyze(problem, Y,
+                       calc_second_order=True, conf_level=0.95, print_to_console=False, parallel=True, n_processors=4)
+```
+
 Other methods include Morris, FAST, Delta-MIM, and DGSM. For an explanation of all command line options for each method, [see the examples here](https://github.com/SALib/SALib/tree/master/examples).

--- a/SALib/tests/test_regression.py
+++ b/SALib/tests/test_regression.py
@@ -94,6 +94,21 @@ def test_regression_sobol():
     assert_allclose([Si['S2'][0][1], Si['S2'][0][2], Si['S2'][1][2]], [0.00, 0.25, 0.00], atol=5e-2, rtol=1e-1)
 
 
+def test_regression_sobol_parallel():
+    param_file = 'SALib/test_functions/params/Ishigami.txt'
+    problem = read_param_file(param_file)
+    param_values = saltelli.sample(problem, 10000, calc_second_order=True)
+
+    Y = Ishigami.evaluate(param_values)
+
+    Si = sobol.analyze(problem, Y,
+                       calc_second_order=True, parallel=True, conf_level=0.95, print_to_console=False)
+
+    assert_allclose(Si['S1'], [0.31, 0.44, 0.00], atol=5e-2, rtol=1e-1)
+    assert_allclose(Si['ST'], [0.55, 0.44, 0.24], atol=5e-2, rtol=1e-1)
+    assert_allclose([Si['S2'][0][1], Si['S2'][0][2], Si['S2'][1][2]], [0.00, 0.25, 0.00], atol=5e-2, rtol=1e-1)
+
+
 def test_regression_fast():
     param_file = 'SALib/test_functions/params/Ishigami.txt'
     problem = read_param_file(param_file)

--- a/SALib/tests/test_sobol.py
+++ b/SALib/tests/test_sobol.py
@@ -3,6 +3,7 @@ from __future__ import division
 from nose.tools import with_setup, eq_, raises
 from numpy.testing import assert_equal, assert_allclose
 import numpy as np
+from scipy.stats import norm
 
 from ..analyze import sobol
 from ..sample import saltelli
@@ -10,41 +11,98 @@ from ..test_functions import Ishigami, Sobol_G
 from ..util import read_param_file
 
 
-def test_sample_size_second_order():
+def setup_samples(N = 500, calc_second_order = True):
     param_file = 'SALib/test_functions/params/Ishigami.txt'
     problem = read_param_file(param_file)
+    param_values = saltelli.sample(problem, N=N, calc_second_order=calc_second_order)
+    return problem,param_values
+
+
+def test_sample_size_second_order():
     N = 500
     D = 3
-    param_values = saltelli.sample(problem, N, calc_second_order=True)
+    problem,param_values = setup_samples(N=N)
     assert_equal(param_values.shape, [N * (2 * D + 2), D])
 
 
 def test_sample_size_first_order():
-    param_file = 'SALib/test_functions/params/Ishigami.txt'
-    problem = read_param_file(param_file)
     N = 500
     D = 3
-    param_values = saltelli.sample(problem, N, calc_second_order=False)
+    problem,param_values = setup_samples(N=N, calc_second_order=False)
     assert_equal(param_values.shape, [N * (D + 2), D])
 
 
 @raises(RuntimeError)
 def test_incorrect_sample_size():
-    param_file = 'SALib/test_functions/params/Ishigami.txt'
-    problem = read_param_file(param_file)
-    param_values = saltelli.sample(problem, 500, calc_second_order=True)
+    problem,param_values = setup_samples()
     Y = Ishigami.evaluate(param_values)
     sobol.analyze(problem, Y[:-10], calc_second_order=True)
 
 
 @raises(RuntimeError)
+def test_bad_conf_level():
+    problem,param_values = setup_samples()
+    Y = Ishigami.evaluate(param_values)
+    Si = sobol.analyze(problem, Y,
+                       calc_second_order=True, conf_level=1.01, print_to_console=False)
+
+
+@raises(RuntimeError)
 def test_incorrect_second_order_setting():
     # note this will still be a problem if N(2D+2) also divides by (D+2)
-    param_file = 'SALib/test_functions/params/Ishigami.txt'
-    problem = read_param_file(param_file)
-    param_values = saltelli.sample(problem, 501, calc_second_order=False)
+    problem,param_values = setup_samples(N=501, calc_second_order=False)
     Y = Ishigami.evaluate(param_values)
     sobol.analyze(problem, Y, calc_second_order=True)
+
+
+def test_include_print():
+    problem,param_values = setup_samples()
+    Y = Ishigami.evaluate(param_values)
+    Si = sobol.analyze(problem, Y,
+                       calc_second_order=True, conf_level=0.95, print_to_console=True)
+
+
+def test_parallel_first_order():
+    c2o = False
+    N = 10000
+    problem,param_values = setup_samples(N=N, calc_second_order=c2o)
+    Y = Ishigami.evaluate(param_values)
+    
+    A,B,AB,BA = sobol.separate_output_values(Y, D=3, N=N, 
+                                            calc_second_order=c2o)
+    r = np.random.randint(N, size=(N, 100))
+    Z = norm.ppf(0.5 + 0.95 / 2)
+    tasks, n_processors = sobol.create_task_list(D=3, 
+                            calc_second_order=c2o, n_processors=None)
+    Si_list = []
+    for t in tasks:
+        Si_list.append(sobol.sobol_parallel(Z, A, AB, BA, B, r, t))
+    Si = sobol.Si_list_to_dict(Si_list, D=3, calc_second_order=c2o)
+
+    assert_allclose(Si['S1'], [0.31, 0.44, 0.00], atol=5e-2, rtol=1e-1)
+    assert_allclose(Si['ST'], [0.55, 0.44, 0.24], atol=5e-2, rtol=1e-1)
+
+
+def test_parallel_second_order():
+    c2o = True
+    N = 10000
+    problem,param_values = setup_samples(N=N, calc_second_order=c2o)
+    Y = Ishigami.evaluate(param_values)
+    
+    A,B,AB,BA = sobol.separate_output_values(Y, D=3, N=N, 
+                                            calc_second_order=c2o)
+    r = np.random.randint(N, size=(N, 100))
+    Z = norm.ppf(0.5 + 0.95 / 2)
+    tasks, n_processors = sobol.create_task_list(D=3, 
+                            calc_second_order=c2o, n_processors=None)
+    Si_list = []
+    for t in tasks:
+        Si_list.append(sobol.sobol_parallel(Z, A, AB, BA, B, r, t))
+    Si = sobol.Si_list_to_dict(Si_list, D=3, calc_second_order=c2o)
+
+    assert_allclose(Si['S1'], [0.31, 0.44, 0.00], atol=5e-2, rtol=1e-1)
+    assert_allclose(Si['ST'], [0.55, 0.44, 0.24], atol=5e-2, rtol=1e-1)
+    assert_allclose([Si['S2'][0][1], Si['S2'][0][2], Si['S2'][1][2]], [0.00, 0.25, 0.00], atol=5e-2, rtol=1e-1)
 
 
 def test_Sobol_G_using_sobol():

--- a/examples/sobol/sobol.py
+++ b/examples/sobol/sobol.py
@@ -21,7 +21,10 @@ Y = Ishigami.evaluate(param_values)
 # Specify which column of the output file to analyze (zero-indexed)
 Si = sobol.analyze(problem, Y, calc_second_order=True, conf_level=0.95, print_to_console=True)
 # Returns a dictionary with keys 'S1', 'S1_conf', 'ST', and 'ST_conf'
-# e.g. Si['S1'] contains the first-order index for each parameter, in the same order as the parameter file
+# e.g. Si['S1'] contains the first-order index for each parameter, 
+# in the same order as the parameter file
 # The optional second-order indices are now returned in keys 'S2', 'S2_conf'
 # These are both upper triangular DxD matrices with nan's in the duplicate
 # entries.
+# Optional keyword arguments parallel=True and n_processors=(int) for parallel execution
+# using multiprocessing

--- a/examples/sobol/sobol.sh
+++ b/examples/sobol/sobol.sh
@@ -54,3 +54,7 @@ python -m SALib.analyze.sobol \
 #               This must match the value chosen during sampling.
 #
 # -r, --resamples (optional): Number of bootstrap resamples used to calculate confidence intervals on indices. Default 1000.
+#
+# --parallel (optional): Flag to enable parallel execution with multiprocessing
+#
+# --processors (optional, int): Number of processors to be used with the parallel option


### PR DESCRIPTION
Ok this should be ready now. A couple of tests to improve coverage of the analyze.sobol function, with/without the parallel option. Also updates examples accordingly.

I'll assume this is ok to merge since it doesn't change any functionality, but let me know if anyone notices something off about it.