### PR TITLE
Group Sampling for Sobol Analysis and Conversion to Non-Uniform Distributions

### DIFF
--- a/SALib/analyze/sobol.py
+++ b/SALib/analyze/sobol.py
@@ -65,7 +65,7 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
     """
     # determining if groups are defined and adjusting the number
     # of rows in the cross-sampled matrix accordingly
-    if problem['groups'] == None:
+    if not problem.get('groups'):
         D = problem['num_vars']
     else:
         D = len(problem['groups'][1])
@@ -118,7 +118,6 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
     # Print results to console
     if print_to_console:
         print_indices(S, problem, calc_second_order)
-
 
     return S
 
@@ -204,7 +203,7 @@ def create_task_list(D, calc_second_order, n_processors):
         tasks_second_order = [[d, j, k] for j in range(D) for k in
                             range(j + 1, D) for d in ('S2', 'S2_conf')]
 
-    if n_processors == None:
+    if n_processors is None:
         n_processors = min(cpu_count(), len(tasks_first_order) + len(tasks_second_order))
 
     if not calc_second_order:
@@ -236,7 +235,7 @@ def Si_list_to_dict(S_list, D, calc_second_order):
 
 def print_indices(S, problem, calc_second_order):
     # Output to console
-    if problem['groups'] == None:
+    if not problem.get('groups'):
         D = problem['num_vars']
         print('Parameter S1 S1_conf ST ST_conf')
 

--- a/SALib/sample/saltelli.py
+++ b/SALib/sample/saltelli.py
@@ -7,9 +7,9 @@ from . import sobol_sequence
 from ..util import scale_samples, read_param_file
 
 
-def sample(problem, N, calc_second_order=True):
+def sample(problem, N, calc_second_order=True,groups=False):
     """Generates model inputs using Saltelli's extension of the Sobol sequence.
-    
+
     Returns a NumPy matrix containing the model inputs using Saltelli's sampling
     scheme.  Saltelli's scheme extends the Sobol sequence in a way to reduce
     the error rates in the resulting sensitivity index calculations.  If
@@ -17,7 +17,7 @@ def sample(problem, N, calc_second_order=True):
     rows, where D is the number of parameters.  If calc_second_order is True,
     the resulting matrix has N * (2D + 2) rows.  These model inputs are
     intended to be used with :func:`SALib.analyze.sobol.analyze`.
-    
+
     Parameters
     ----------
     problem : dict
@@ -26,7 +26,17 @@ def sample(problem, N, calc_second_order=True):
         The number of samples to generate
     calc_second_order : bool
         Calculate second-order sensitivities (default True)
+    groups : bool
+        Cross-sample based on groups of parameters
     """
+    # finding number of groups of groups, Dg
+    # if groups = False, number of groups is the number of variables
+    if groups:
+        Dg = len(problem['groups'])
+    else:
+        Dg = problem['num_vars']
+
+    # number of variables
     D = problem['num_vars']
 
     # How many values of the Sobol sequence to skip
@@ -36,9 +46,9 @@ def sample(problem, N, calc_second_order=True):
     base_sequence = sobol_sequence.sample(N + skip_values, 2 * D)
 
     if calc_second_order:
-        saltelli_sequence = np.empty([(2 * D + 2) * N, D])
+        saltelli_sequence = np.empty([(2 * Dg + 2) * N, D])
     else:
-        saltelli_sequence = np.empty([(D + 2) * N, D])
+        saltelli_sequence = np.empty([(Dg + 2) * N, D])
     index = 0
 
     for i in range(skip_values, N + skip_values):
@@ -50,26 +60,71 @@ def sample(problem, N, calc_second_order=True):
         index += 1
 
         # Cross-sample elements of "B" into "A"
-        for k in range(D):
-            for j in range(D):
-                if j == k:
-                    saltelli_sequence[index, j] = base_sequence[i, j + D]
-                else:
-                    saltelli_sequence[index, j] = base_sequence[i, j]
+        if groups:
+            # method of cross-sampling "B" into "A" for groups
+            # groups that are "off-diagonal" (l != m) will be drawn from "A"
+            # groups that are "on-diagonal" (l = m) will be drawn from "B"
+            for l in range(len(problem['groups'])):
+                for m in range(len(problem['groups'])):
+                    if l == m:
+                        # condition for being "on-diagonal" group
+                        # "on-diagonal" groups have elements taken from "B"
+                        for k in range(len(problem['groups'][m])):
+                            j = problem['names'].index(problem['groups'][m][k])
+                            saltelli_sequence[index, j] = base_sequence[i, j + D]
+                    else:
+                        # condition for being "off-diagonal" group
+                        # "off-diagonal" groups have elements taken from "A"
+                        for k in range(len(problem['groups'][m])):
+                            j = problem['names'].index(problem['groups'][m][k])
+                            saltelli_sequence[index, j] = base_sequence[i, j]
 
-            index += 1
+                index += 1
+        else:
+            # cross-sampling without groups
+            for k in range(D):
+                for j in range(D):
+                    if j == k:
+                        saltelli_sequence[index, j] = base_sequence[i, j + D]
+                    else:
+                        saltelli_sequence[index, j] = base_sequence[i, j]
+
+                index += 1
 
         # Cross-sample elements of "A" into "B"
         # Only needed if you're doing second-order indices (true by default)
         if calc_second_order:
-            for k in range(D):
-                for j in range(D):
-                    if j == k:
-                        saltelli_sequence[index, j] = base_sequence[i, j]
-                    else:
-                        saltelli_sequence[index, j] = base_sequence[i, j + D]
+            if groups:
+                # method of cross-sampling "A" into "B" for groups
+                # groups that are "off-diagonal" (l != m) will be drawn from "B"
+                # groups that are "on-diagonal" (l = m) will be drawn from "A"
+                for l in range(len(problem['groups'])):
+                    for m in range(len(problem['groups'])):
+                        if l == m:
+                            # condition for being "on-diagonal" group
+                            # "on-diagonal" groups have elements taken from "A"
+                            for k in range(len(problem['groups'][m])):
+                                j = problem['names'].index(problem['groups'][m][k])
+                                saltelli_sequence[index, j] = base_sequence[i, j]
+                        else:
+                            # condition for being "off-diagonal" group
+                            # "off-diagonal" groups have elements taken from "B"
+                            for k in range(len(problem['groups'][m])):
+                                j = problem['names'].index(problem['groups'][m][k])
+                                saltelli_sequence[index, j] = base_sequence[i, j+D]
 
-                index += 1
+                    index += 1
+
+            else:
+                # cross-sampling without groups
+                for k in range(D):
+                    for j in range(D):
+                        if j == k:
+                            saltelli_sequence[index, j] = base_sequence[i, j]
+                        else:
+                            saltelli_sequence[index, j] = base_sequence[i, j + D]
+
+                    index += 1
 
         # Copy matrix "B"
         for j in range(D):
@@ -83,10 +138,10 @@ def sample(problem, N, calc_second_order=True):
 if __name__ == "__main__":
 
     parser = common_args.create()
-    
+
     parser.add_argument(
         '-n', '--samples', type=int, required=True, help='Number of Samples')
-   
+
     parser.add_argument('--max-order', type=int, required=False, default=2,
                         choices=[1, 2], help='Maximum order of sensitivity indices to calculate')
     args = parser.parse_args()

--- a/SALib/sample/saltelli.py
+++ b/SALib/sample/saltelli.py
@@ -113,7 +113,7 @@ def sample(problem, N, calc_second_order=True):
         index += 1
     if problem['dists'] == None:
         # scaling values out of 0-1 range with uniform distributions
-        scale_samples(saltelli_sequence,problem['bounds'],None)
+        scale_samples(saltelli_sequence,problem['bounds'])
         return saltelli_sequence
     else:
         # scaling values to other distributions based on inverse CDFs

--- a/SALib/util/__init__.py
+++ b/SALib/util/__init__.py
@@ -6,7 +6,7 @@ from warnings import warn
 import numpy as np
 import scipy as sp
 
-def scale_samples(params, bounds, dists=None):
+def scale_samples(params, bounds, dists):
     '''
     Rescales samples in 0-to-1 range to arbitrary bounds.
 
@@ -14,108 +14,24 @@ def scale_samples(params, bounds, dists=None):
         bounds - list of lists of dimensions num_params-by-2
         params - numpy array of dimensions num_params-by-N,
         where N is the number of samples
-        dists - vector of distribution names, None implies uniform
     '''
-    if dists == None:
-        # computations when only uniform distributoins are used
-		
-        # Check bounds are legal (upper bound is greater than lower bound)
-        b = np.array(bounds)
-        lower_bounds = b[:, 0]
-        upper_bounds = b[:, 1]
-		
-        if np.any(lower_bounds >= upper_bounds):
-            raise ValueError("Bounds are not legal")
-		
-        # This scales the samples in-place, by using the optional output
-        # argument for the numpy ufunctions
-        # The calculation is equivalent to:
-        #   sample * (upper_bound - lower_bound) + lower_bound
-        np.add(np.multiply(params,
-                           (upper_bounds - lower_bounds),
-                           out=params),
-               lower_bounds,
-               out=params)
-	
-    else:
-    	# computations for non-uniform distributions
-    	
-        # initializing matrix to hold converted values
-        conv_param =  np.empty([len(params),len(params[0])])
-		
-        if len(dists) != len(params[0]):
-            print('Invalid number of distributions')
-			
-        for i in range(len(dists)):
-            # loop over variables and converting them one by one into specified distributions
-            
-            # uniform distribution
-            if dists[i] == 'unif':
-                arg1 = bounds[i][0] # lower bound
-                arg2 = bounds[i][1] # upper bound
-                
-                # printing error when upper bound is less than lower bound
-                if arg1 > arg2:
-                    print('Upper bound must be less than lower bound')
-                else:
-                    conv_param[:,i] = params[:,i]*(arg2-arg1) + arg1
-					
-			# normal distribution
-            elif dists[i] == 'norm':
-                arg1 = bounds[i][0] # mean
-                arg2 = bounds[i][1] # standard deviation
-                
-                # printing error when standard deviation is not positive
-                if arg2 <= 0:
-                    print('Standard deviation must be positive')
-                else:
-                    conv_param[:,i] = sp.stats.norm.ppf(params[:,i],loc=arg1,scale=arg2)
-					
-			# log-normal distribution (base-e not base-10)
-            elif dists[i] == 'lognorm':
-                arg1 = bounds[i][0] # ln-space mean
-                arg2 = bounds[i][1] # ln-space standard deviation
-                
-                # checking if real-space lower bound is specified
-                if(len(bound[i]) == 3):
-                    arg3 = bounds[i][2]
-                else:
-                    arg3 = 0. # lower bound
-                
-                # printing error if log-space standard deviation is not positive
-                if arg2[i] <= 0:
-                    print('Standard deviation must be positive')
-                else:
-                    conv_param[:,i] = exp(sp.stats.norm.ppf(params[:,i],loc=arg1,scale=arg2))+arg3
-			
-			# triangular distribution
-            elif dists[i] == 'triang':
-                arg1 = bounds[i][0] # lower bound
-                arg2 = bounds[i][1] # upper bound
-                
-                # condition is most-likely value specified
-                # if not specified, use average of upper and lower bounds
-                if(len(bound[i]) == 3):
-                    arg3 = bounds[i][2] # most likely
-                else:
-                    arg3 = np.mean([arg1,arg2]) # lower bound
-                
-                # checking upper bound less than lower bound
-                # and that most likely value within the bounds
-                if arg1 > arg2:
-                    print('Upper bound must be greater than lower bound')
-                elif (arg3 < arg1) or (arg3 > arg2):
-                    print('Most likely value must be within upper and lower bounds')
-                else:
-                    a = arg1 # location (lower bound)
-                    b = arg2 - arg1 # scale (width of distribution)
-                    c = (arg3-a)/b # most likely as percentage of scale
-                    conv_param[:,i] = sp.stats.triang.ppf(params[:,i],c=c,loc=a,scale=b)
-            
-            # error message for a distribution type that is not valid
-            else:
-                print('Not a valid distribution type')
-    	return(conv_param)
+    # Check bounds are legal (upper bound is greater than lower bound)
+    b = np.array(bounds)
+    lower_bounds = b[:, 0]
+    upper_bounds = b[:, 1]
+
+    if np.any(lower_bounds >= upper_bounds):
+        raise ValueError("Bounds are not legal")
+
+    # This scales the samples in-place, by using the optional output
+    # argument for the numpy ufunctions
+    # The calculation is equivalent to:
+    #   sample * (upper_bound - lower_bound) + lower_bound
+    np.add(np.multiply(params,
+                       (upper_bounds - lower_bounds),
+                       out=params),
+           lower_bounds,
+           out=params)
 
 def unscale_samples(params, bounds):
     '''
@@ -142,12 +58,98 @@ def unscale_samples(params, bounds):
               np.subtract(upper_bounds, lower_bounds),
               out=params)
 
+def nonuniform_scale_samples(params, bounds, dists):
+    '''
+    Rescales samples in 0-to-1 range to other distributions.
+
+    Arguments:
+        problem - problem definition including bounds
+        params - numpy array of dimensions num_params-by-N,
+            where N is the number of samples
+        dists-list of distributions, one for each parameter
+                unif: uniform with lower and upper bounds
+                triang: triangular with width (scale) and location of peak
+                        location of peak is in percentage of width
+                        lower bound assumed to be zero
+                norm: normal distribution with mean and standard deviation
+                lognorm: lognormal with ln-space mean and standard deviation
+    '''
+    b = np.array(bounds)
+    
+    if len(params[0]) != len(dists):
+        print('Incorrect number of distributions specified')
+        print('Original parameters returned')
+        return params
+    else:
+        # initializing matrix for converted values
+        conv_params = np.empty([len(params),len(params[0])])
+
+        # loop over the parameters
+        for i in range(len(conv_params[0])):
+            # setting first and second arguments for distributions
+            arg1 = b[i][0]
+            arg2 = b[i][1]
+
+            # triangular distribution
+            # paramters are width (scale) and location of peak
+            # location of peak is relative to scale
+            # e.g., 0.25 means peak is 25% of the width distance from zero
+            if dists[i] == 'triang':
+                # checking for correct parameters
+                if arg1 <= 0:
+                    print('Scale must be greater than zero')
+                    print('Parameter not converted')
+                    conv_params[:,i] = params[:,i]
+                elif (arg2 <= 0) or (arg2 >= 1):
+                    print('Peak must be on interval [0,1]')
+                    print('Parameter not converted')
+                    conv_params[:,i] = params[:,i]
+                else:
+                    conv_params[:,i] = sp.stats.triang.ppf(params[:,i],c=arg2,scale=arg1,loc=0)
+
+            # uniform distribution
+            # parameters are lower and upper bounds
+            elif dists[i] == 'unif':
+                # checking that upper bound is greater than lower bound
+                if arg1 >= arg2:
+                    print('Lower bound greater than upper bound')
+                    print('Parameter not converted')
+                    conv_params[:,i] = params[:,i]
+                else:
+                    conv_params[:,i] = params[:,i]*(arg2-arg1) + arg1
+
+            # normal distribution
+            # paramters are mean and standard deviation
+            elif dists[i] == 'norm':
+                # checking for valid parameters
+                if arg2 <= 0:
+                    print('Scale must be greater than zero')
+                    print('Parameter not converted')
+                    conv_params[:,i] = params[:,i]
+                else:
+                    conv_params[:,i] = sp.stats.norm.ppf(params[:,i],loc=arg1,scale=arg2)
+
+            # lognormal distribution (ln-space, not base-10)
+            # paramters are ln-space mean and standard deviation
+            elif dists[i] == 'lognorm':
+                # checking for valid parameters
+                if arg2 <= 0:
+                    print('Scale must be greater than zero')
+                    print('Parameter not converted')
+                    conv_params[:,i] = params[:,i]
+                else:
+                    conv_params[:,i] = np.exp(sp.stats.norm.ppf(params[:,i],loc=arg1,scale=arg2))
+
+            else:
+                print('No valid distribution selected')
+    return(conv_params)
+
 def read_param_file(filename, delimiter=None):
     '''
     Reads a parameter file of format:
-        Param1,0,1,Group1
-        Param2,0,1,Group2
-        Param3,0,1,Group3
+        Param1,0,1,Group1,dist1
+        Param2,0,1,Group2,dist2
+        Param3,0,1,Group3,dist3
     And returns a dictionary containing:
         - names - the names of the parameters
         - bounds - a list of lists of lower and upper bounds
@@ -156,12 +158,16 @@ def read_param_file(filename, delimiter=None):
         - groups - a tuple containing i) a group matrix assigning parameters to
                    groups
                                       ii) a list of unique group names
+        - dists - a list of distributions for the problem,
+                    None if not specified or all uniform
     '''
     names = []
     bounds = []
     group_list = []
+    dist_list = []
     num_vars = 0
-    fieldnames = ['name', 'lower_bound', 'upper_bound', 'group']
+    fieldnames = ['name', 'lower_bound', 'upper_bound', 'group', 'dist']
+    dist_none_count = 0 # used when evaluating if non-uniform distributions are specified
 
     with open(filename, 'rU') as csvfile:
         dialect = csv.Sniffer().sniff(csvfile.read(1024), delimiters=delimiter)
@@ -181,19 +187,38 @@ def read_param_file(filename, delimiter=None):
                 # the parameter name
                 if row['group'] is None:
                     group_list.append(row['name'])
+                elif row['group'] is 'NA':
+                    group_list.append(row['name'])
                 else:
                     group_list.append(row['group'])
 
-        group_matrix, group_names = compute_groups_from_parameter_file(
-            group_list, num_vars)
+                # If the fifth column does not contain a distribution
+                # use uniform
+                if row['dist'] is None:
+                    dist_list.append('unif')
+                    dist_none_count += 1
+                else:
+                    dist_list.append(row['dist'])
 
-        if np.all(group_matrix == np.eye(num_vars)):
-            group_tuple = None
-        else:
-            group_tuple = (group_matrix, group_names)
+    group_matrix, group_names = compute_groups_from_parameter_file(
+        group_list, num_vars)
+
+    # setting group_tuple to zero if no groups are defined
+    # or all groups are 'NA'
+    if np.all(group_matrix == np.eye(num_vars)):
+        group_tuple = None
+    elif len(np.unique(group_list)) == 1:
+        group_tuple = None
+    else:
+        group_tuple = (group_matrix, group_names)
+
+    # setting dist list to none if all are uniform
+    # because non-uniform scaling is not needed
+    if dist_none_count == num_vars:
+        dist_list = None
 
     return {'names': names, 'bounds': bounds, 'num_vars': num_vars,
-            'groups': group_tuple}
+            'groups': group_tuple, 'dists': dist_list}
 
 
 def compute_groups_from_parameter_file(group_list, num_vars):

--- a/SALib/util/__init__.py
+++ b/SALib/util/__init__.py
@@ -6,7 +6,7 @@ from warnings import warn
 import numpy as np
 import scipy as sp
 
-def scale_samples(params, bounds, dists):
+def scale_samples(params, bounds):
     '''
     Rescales samples in 0-to-1 range to arbitrary bounds.
 
@@ -75,7 +75,7 @@ def nonuniform_scale_samples(params, bounds, dists):
                 lognorm: lognormal with ln-space mean and standard deviation
     '''
     b = np.array(bounds)
-    
+
     if len(params[0]) != len(dists):
         print('Incorrect number of distributions specified')
         print('Original parameters returned')


### PR DESCRIPTION
The changes are in two separate areas: group sampling for Sobol sensitivity analysis and conversion of uniform 0-to-1 uniform variables into other distributions. More detailed descriptions are provided below. 

Group sampling for Sobol indices makes changes to the files saltelli.py and sobol.py. In saltelli.py, the sample function was modified to add a condition for if group sampling is desired (default groups=False). If this is the case the code uses the previous method. If group sampling is desired, then instead of looping over parameters when cross-sampling the matrices, groups are looped-over with a nested loop to account for the variables within each group. The size of the matrices also changes because instead of 'D' variables in the previous code there are now 'Dg' groups. The change in sobol.py  is in the analyze function, where the additional 'groups' parameter was added and the the number of rows in the cross-sampled matrix was changed based on whether there was group sampling.

Conversion to non-uniform distributions caused changes in __init__.py and and saltelli.py. The changes in __init__py were to the scaled_samples function, where a parameter was added for 'dists' (default 'dists=None'). With the default value, the standard uniforms are converted to non-standard uniforms as before. However, when a vector of distributions is passed to the function the variables in the 'bounds' file will be used to convert the standard uniform values to the required distribution using the inverse cumulative distribution function (spicy.stats library). The possible distributions include uniform, normal, lognormal, and triangular. The change to saltelli.py is in the sample function, where an if/else condition near the end controls the call to scaled_samples and there is an additional parameter added for non-uniform distributions.