### PR TITLE
Bugfix 114 and 127

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2015 Jon Herman, Will Usher, and others.
+Copyright (c) 2013-2017 Jon Herman, Will Usher, and others.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ Lots of other options are included for parameter files, as well as a command-lin
 Also check out the [examples](https://github.com/SALib/SALib/tree/master/examples) for a full description of options for each method.
 
 ### License
-Copyright (C) 2016 Jon Herman, Will Usher, and others. Versions v0.5 and later are released under the [MIT license](LICENSE.md).
+Copyright (C) 2017 Jon Herman, Will Usher, and others. Versions v0.5 and later are released under the [MIT license](LICENSE.md).

--- a/SALib/analyze/morris.py
+++ b/SALib/analyze/morris.py
@@ -69,9 +69,9 @@ def analyze(problem, X, Y,
 
     num_vars = problem['num_vars']
 
-    if (problem['groups'] is None) & (Y.size % (num_vars + 1) == 0):
+    if (problem.get('groups') is None) & (Y.size % (num_vars + 1) == 0):
         num_trajectories = int(Y.size / (num_vars + 1))
-    elif problem['groups'] is not None:
+    elif problem.get('groups') is not None:
         groups, unique_group_names = compute_groups_matrix(problem['groups'], num_vars)
         number_of_groups = len(unique_group_names)
         num_trajectories = int(Y.size / (number_of_groups + 1))

--- a/SALib/analyze/sobol.py
+++ b/SALib/analyze/sobol.py
@@ -83,6 +83,9 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
     if conf_level < 0 or conf_level > 1:
         raise RuntimeError("Confidence level must be between 0-1.")
 
+    # normalize the model output
+    Y = (Y - Y.mean())/Y.std()
+    
     A,B,AB,BA = separate_output_values(Y, D, N, calc_second_order)
     r = np.random.randint(N, size=(N, num_resamples))
     Z = norm.ppf(0.5 + conf_level / 2)


### PR DESCRIPTION
A couple of small changes to clean up before we release an updated version.

* Fixes #127 (using `problem.get('groups')` in analyze.morris)

* Fixes #114, and by extension #109, by normalizing the model output in analyze.sobol using the suggestion by @sofianehaddad (`Y = (Y - Y.mean()) / Y.std()`)