### PR TITLE
continuous deployment when tags pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-# Travis config for SALib/SALib
 sudo: false
 language: python
 virtualenv:
   system_site_packages: true
 services:
-  - postgresql
+- postgresql
 env:
   matrix:
   - DISTRIB="conda" PYTHON_VERSION="2.7" COVERAGE="true"
@@ -24,4 +23,11 @@ after_success:
 cache:
 - apt
 notifications:
- email: false
+  email: false
+deploy:
+  provider: pypi
+  on:
+    tags: true
+  user: jdherman
+  password:
+    secure: KiUygZVHWMR2a+fk092xeHh8J2c61VGrgq4v1l3bq41MxcZO745H7CLJJ3rfqo+G5/pqy4/tm+q3p8fHhbUmwMcuSC3vjRN6WAYjuNPs0FMVXiIkMQtevv2LdVF1zVKFBdYTuNrfugtZ/GXh/ReCydjEBWTrTaNYeNM4ZRIaj0Q=


### PR DESCRIPTION
As suggested by @willu47 in #142 

Have not tested this, because it will only deploy from master. We'll have to merge and then test it by pushing some tags:
```
git tag v1.0.x
git push --tags
```
(at least this is how I've been doing it -- there is probably a better way)
