### PR TITLE
Updated morris docstring with groups and optimal trajectories

### DIFF
--- a/SALib/sample/morris/__init__.py
+++ b/SALib/sample/morris/__init__.py
@@ -53,9 +53,13 @@ def sample(problem, N, num_levels, grid_jump, optimal_trajectories=None,
     """Generate model inputs using the Method of Morris
 
     Returns a NumPy matrix containing the model inputs required for Method of
-    Morris.  The resulting matrix has :math:`(D+1)*N` rows and :math:`D`
-    columns, where :math:`D` is the number of parameters.  These model inputs
-    are intended to be used with :func:`SALib.analyze.morris.analyze`.
+    Morris.  The resulting matrix has :math:`(G+1)*T` rows and :math:`D`
+    columns, where :math:`D` is the number of parameters, :math:`G` is the
+    number of groups (if no groups are selected, the number of parameters).
+    :math:`T` is the number of trajectories :math:`N`,
+    or `optimal_trajectories` if selected.
+    These model inputs  are intended to be used with
+    :func:`SALib.analyze.morris.analyze`.
 
     Parameters
     ----------
@@ -79,8 +83,8 @@ def sample(problem, N, num_levels, grid_jump, optimal_trajectories=None,
     -------
     sample : numpy.ndarray
         Returns a numpy.ndarray containing the model inputs required for Method
-        of Morris. The resulting matrix has :math:`(D+1)*N` rows and :math:`D`
-        columns, where :math:`D` is the number of parameters.
+        of Morris. The resulting matrix has :math:`(G/D+1)*N/T` rows and
+        :math:`D` columns, where :math:`D` is the number of parameters.
     """
     if grid_jump >= num_levels:
         raise ValueError("grid_jump must be less than num_levels")
@@ -161,8 +165,9 @@ def _sample_oat(problem, N, num_levels, grid_jump):
 def _sample_groups(problem, N, num_levels, grid_jump):
     """Generate trajectories for groups
 
-    Returns an N(g+1)-by-k array of N trajectories;
-    where g is the number of groups and k is the number of factors
+    Returns an :math:`N(g+1)`-by-:math:`k` array of `N` trajectories,
+    where :math:`g` is the number of groups and :math:`k` is the number
+    of factors
 
     Arguments
     ---------


### PR DESCRIPTION
Fixes #103 - the size of the Morris sample depends on the number of parameters *or* groups, and the number of trajectories *or* optimal trajectories, depending on whether groups are used, optimal trajectories are used.