### PR TITLE
Fix for pypi deployment bug due to dirty repo after conda setup

### DIFF
--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -14,8 +14,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # Use the miniconda installer for faster download / install of conda
     # itself
     wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
-        -O miniconda.sh
-    chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+        -O $HOME/miniconda.sh
+    chmod +x $HOME/miniconda.sh && .$HOME/miniconda.sh -b -p $HOME/miniconda
     export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
 

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -18,7 +18,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
     wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
         -O $DOWNLOAD_DIR/miniconda.sh
     chmod +x $DOWNLOAD_DIR/miniconda.sh && \
-        bash $DOWNLOAD_DIR/miniconda.sh -b -p $HOME/miniconda
+        bash $DOWNLOAD_DIR/miniconda.sh -b -p $HOME/miniconda && \
+        rm -r -d -f $DOWNLOAD_DIR
     export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
 

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # This script is meant to be called by the "install" step defined in
 # .travis.yml. See http://docs.travis-ci.com/ for more details.
 # The behavior of the script is controlled by environment variabled defined
@@ -13,9 +13,12 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     # Use the miniconda installer for faster download / install of conda
     # itself
+    DOWNLOAD_DIR=$HOME/download
+    mkdir -p $DOWNLOAD_DIR
     wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
-        -O $HOME/miniconda.sh
-    chmod +x $HOME/miniconda.sh && .$HOME/miniconda.sh -b -p $HOME/miniconda
+        -O $DOWNLOAD_DIR/miniconda.sh
+    chmod +x $DOWNLOAD_DIR/miniconda.sh && \
+        bash $DOWNLOAD_DIR/miniconda.sh -b -p $HOME/miniconda
     export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
 


### PR DESCRIPTION
Automatic deployment to PyPi was failing because the conda setup script in `tests/travis_install.sh` downloaded the miniconda install file `miniconda.sh` into the repo directory on the test server. This caused the repo to be 'dirtied' and caused the sdist build upload to fail because a dirty version number (autogenerated by PyScaffold and pbr) doesn't meet PEP440 standards required by the PyPi server.