### PR TITLE
Patch docs groups

### DIFF
--- a/README-advanced.md
+++ b/README-advanced.md
@@ -1,18 +1,18 @@
-### SALib: Advanced options
+## SALib: Advanced options
 
-#### Parameter files
+### Parameter files
 
-In the parameter file, lines beginning with `#` will be treated as comments and ignored. The Morris method also supports groups of input factors, which can be specified with a fourth column:
+In the parameter file, lines beginning with `#` will be treated as comments and ignored.
 ```
-# name lower_bound upper_bound group_name
-P1 0.0 1.0 Group_1
-P2 0.0 5.0 Group_2
-P3 0.0 5.0 Group_2
+# name lower_bound upper_bound
+P1 0.0 1.0
+P2 0.0 5.0
+P3 0.0 5.0
 ...etc.
 ```
 Parameter files can also be comma-delimited if your parameter names or group names contain spaces. This should be detected automatically.
 
-#### Command-line interface
+### Command-line interface
 
 **Generate samples** (the `-p` flag is the parameter file)
 ```
@@ -34,10 +34,54 @@ python -m SALib.analyze.sobol \
 
 This will print indices and confidence intervals to the command line. You can redirect to a file using the `>` operator.
 
-#### Parallel indices calculation (Sobol method only)
+### Parallel indices calculation (Sobol method only)
 ```python
 Si = sobol.analyze(problem, Y,
                        calc_second_order=True, conf_level=0.95, print_to_console=False, parallel=True, n_processors=4)
 ```
 
 Other methods include Morris, FAST, Delta-MIM, and DGSM. For an explanation of all command line options for each method, [see the examples here](https://github.com/SALib/SALib/tree/master/examples).
+
+
+### Groups of variables (Sobol and Morris methods only)
+It is sometimes useful to perform sensitivity analysis on groups of input variables to reduce the number of model runs required, when variables belong to the same component of a model, or there is some reason to believe that they should behave similarly.
+
+Groups can be specified in two ways for the Sobol and Morris methods. First, as a fourth column in the parameter file:
+```
+# name lower_bound upper_bound group_name
+P1 0.0 1.0 Group_1
+P2 0.0 5.0 Group_2
+P3 0.0 5.0 Group_2
+...etc.
+```
+
+Or in the `problem` dictionary:
+```python
+problem = {
+  'groups': ['Group_1', 'Group_2', 'Group_2'],
+  'names': ['x1', 'x2', 'x3'],
+  'num_vars': 3,
+  'bounds': [[-3.14, 3.14], [-3.14, 3.14], [-3.14, 3.14]]
+}
+```
+
+`groups` is a list of strings specifying the group name to which each variable belongs. The rest of the code stays the same:
+
+```python
+param_values = saltelli.sample(problem, 1000)
+Y = Ishigami.evaluate(param_values)
+Si = sobol.analyze(problem, Y, print_to_console=True)
+```
+
+But the output is printed by group:
+```
+Group S1 S1_conf ST ST_conf
+Group_1 0.307834 0.066424 0.559577 0.082978
+Group_2 0.444052 0.080255 0.667258 0.060871
+
+Group_1 Group_2 S2 S2_conf
+Group_1 Group_2 0.242964 0.124229
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ problem = {
 }
 
 # Generate samples
-param_values = saltelli.sample(problem, 1000, calc_second_order=False)
+param_values = saltelli.sample(problem, 1000)
 
 # Run model (example)
 Y = Ishigami.evaluate(param_values)

--- a/SALib/analyze/morris.py
+++ b/SALib/analyze/morris.py
@@ -90,7 +90,7 @@ def analyze(problem, X, Y,
         num_trajectories = int(Y.size / (num_vars + 1))
     elif problem.get('groups') is not None:
         groups, unique_group_names = compute_groups_matrix(
-            problem['groups'], num_vars)
+            problem['groups'])
         number_of_groups = len(unique_group_names)
         num_trajectories = int(Y.size / (number_of_groups + 1))
     else:

--- a/SALib/analyze/sobol.py
+++ b/SALib/analyze/sobol.py
@@ -245,7 +245,7 @@ def print_indices(S, problem, calc_second_order):
         D = problem['num_vars']
     else:
         title = 'Group'
-        _,names = compute_groups_matrix(problem['groups'], problem['num_vars'])
+        _,names = compute_groups_matrix(problem['groups'])
         D = len(names)
 
     print('%s S1 S1_conf ST ST_conf' % title)

--- a/SALib/sample/morris/__init__.py
+++ b/SALib/sample/morris/__init__.py
@@ -184,8 +184,7 @@ def _sample_groups(problem, N, num_levels, grid_jump):
     -------
     numpy.ndarray
     """
-    group_membership, _ = compute_groups_matrix(problem['groups'],
-                                                problem['num_vars'])
+    group_membership, _ = compute_groups_matrix(problem['groups'])
 
     if group_membership is None:
         raise ValueError("Please define the matrix group_membership.")
@@ -351,7 +350,7 @@ def _compute_optimised_trajectories(problem, input_sample, N, k_choices,
         raise ValueError(msg)
 
     num_params = problem['num_vars']
-    groups = compute_groups_matrix(problem['groups'], num_params)
+    groups = compute_groups_matrix(problem['groups'])
 
     if np.any((input_sample < 0) | (input_sample > 1)):
         raise ValueError("Input sample must be scaled between 0 and 1")

--- a/SALib/sample/morris/__init__.py
+++ b/SALib/sample/morris/__init__.py
@@ -350,7 +350,6 @@ def _compute_optimised_trajectories(problem, input_sample, N, k_choices,
         raise ValueError(msg)
 
     num_params = problem['num_vars']
-    groups = compute_groups_matrix(problem['groups'])
 
     if np.any((input_sample < 0) | (input_sample > 1)):
         raise ValueError("Input sample must be scaled between 0 and 1")
@@ -365,9 +364,14 @@ def _compute_optimised_trajectories(problem, input_sample, N, k_choices,
         # Use brute force approach
         strategy = BruteForce()
 
+    if problem.get('groups'):
+        num_groups = len(set(problem['groups']))
+    else:
+        num_groups = None
+
     context = SampleMorris(strategy)
     output = context.sample(input_sample, N, num_params,
-                            k_choices, groups)
+                            k_choices, num_groups)
 
     return output
 

--- a/SALib/sample/morris/brute.py
+++ b/SALib/sample/morris/brute.py
@@ -12,13 +12,13 @@ class BruteForce(Strategy):
     """
 
     def _sample(self, input_sample, num_samples,
-                num_params, k_choices, groups):
+                num_params, k_choices, num_groups=None):
         return self.brute_force_most_distant(input_sample, num_samples,
-                                             num_params, k_choices, groups)
+                                             num_params, k_choices, num_groups)
 
     def brute_force_most_distant(self, input_sample, num_samples,
                                  num_params, k_choices,
-                                 groups=None):
+                                 num_groups=None):
         """Use brute force method to find most distant trajectories
 
         Arguments
@@ -30,8 +30,8 @@ class BruteForce(Strategy):
             The number of parameters
         k_choices : int
             The number of optimal trajectories
-        groups : tuple
-            A tuple of (numpy.ndarray, list)
+        num_groups : int, default=None
+            The number of groups
 
         Returns
         -------
@@ -41,14 +41,14 @@ class BruteForce(Strategy):
                                         num_samples,
                                         num_params,
                                         k_choices,
-                                        groups)
+                                        num_groups)
 
         maximum_combo = self.find_maximum(scores, num_samples, k_choices)
 
         return maximum_combo
 
     def find_most_distant(self, input_sample, num_samples,
-                          num_params, k_choices, groups=None):
+                          num_params, k_choices, num_groups=None):
         """
         Finds the 'k_choices' most distant choices from the
         'num_samples' trajectories contained in 'input_sample'
@@ -62,8 +62,8 @@ class BruteForce(Strategy):
             The number of parameters
         k_choices : int
             The number of optimal trajectories
-        groups : tuple
-            A tuple of (numpy.ndarray, list)
+        num_groups : int, default=None
+            The number of groups
 
         Returns
         -------
@@ -79,7 +79,7 @@ class BruteForce(Strategy):
         distance_matrix = self.compute_distance_matrix(input_sample,
                                                        num_samples,
                                                        num_params,
-                                                       groups)
+                                                       num_groups)
 
         # Initialise the output array
         chunk = int(1e6)

--- a/SALib/sample/morris/gurobi.py
+++ b/SALib/sample/morris/gurobi.py
@@ -36,9 +36,9 @@ class GlobalOptimisation(Strategy):
     """
 
     def _sample(self, input_sample, num_samples,
-                num_params, k_choices, groups):
+                num_params, k_choices, num_groups=None):
         return self.return_max_combo(input_sample, num_samples,
-                                     num_params, k_choices, groups)
+                                     num_params, k_choices, num_groups)
 
     @staticmethod
     def global_model(N, k_choices, distance_matrix):
@@ -82,7 +82,7 @@ class GlobalOptimisation(Strategy):
         return model
 
     def return_max_combo(self, input_data, N, num_params,
-                         k_choices, groups=None):
+                         k_choices, num_groups=None):
         """Find the optimal combination of most different trajectories
 
         Arguments
@@ -94,7 +94,8 @@ class GlobalOptimisation(Strategy):
             The number of factors
         k_choices : int
             The number of optimal trajectories to select
-        groups: tuple, default=None
+        num_groups: int, default=None
+            The number of groups
 
         Returns
         -------
@@ -102,7 +103,7 @@ class GlobalOptimisation(Strategy):
         """
 
         distance_matrix = self.compute_distance_matrix(
-            input_data, N, num_params, groups)
+            input_data, N, num_params, num_groups)
 
         model = self.global_model(N, k_choices, distance_matrix)
         model.params.Threads = 0

--- a/SALib/sample/morris/local.py
+++ b/SALib/sample/morris/local.py
@@ -11,12 +11,12 @@ class LocalOptimisation(Strategy):
     """
 
     def _sample(self, input_sample, num_samples,
-                num_params, k_choices, groups):
+                num_params, k_choices, num_groups=None):
         return self.find_local_maximum(input_sample, num_samples, num_params,
-                                       k_choices, groups)
+                                       k_choices, num_groups)
 
     def find_local_maximum(self, input_sample, N, num_params,
-                           k_choices, groups=None):
+                           k_choices, num_groups=None):
         """Find the most different trajectories in the input sample using a
         local approach
 
@@ -34,14 +34,14 @@ class LocalOptimisation(Strategy):
             The number of factors
         k_choices : int
             The number of optimal trajectories to return
-        groups : tuple, default=None
-            A tuple containing (group matrix, name list)
+        num_groups : int, default=None
+            The number of groups
         Returns
         -------
         list
         """
         distance_matrix = self.compute_distance_matrix(input_sample, N,
-                                                       num_params, groups,
+                                                       num_params, num_groups,
                                                        local_optimization=True)
 
         tot_indices_list = []

--- a/SALib/sample/morris/strategy.py
+++ b/SALib/sample/morris/strategy.py
@@ -27,7 +27,8 @@ class SampleMorris(object):
     def __init__(self, strategy):
         self._strategy = strategy
 
-    def sample(self, input_sample, num_samples, num_params, k_choices, groups):
+    def sample(self, input_sample, num_samples, num_params, k_choices,
+               num_groups):
         """Computes the optimum k_choices of trajectories
         from the input_sample.
 
@@ -40,8 +41,8 @@ class SampleMorris(object):
             The number of parameters
         k_choices : int
             The number of optimal trajectories
-        groups : tuple
-            A tuple of (numpy.ndarray, list)
+        num_groups : int
+            The number of groups
 
         Returns
         -------
@@ -49,7 +50,7 @@ class SampleMorris(object):
             An array of optimal trajectories
         """
         return self._strategy.sample(input_sample, num_samples, num_params,
-                                     k_choices, groups)
+                                     k_choices, num_groups)
 
 
 class Strategy:
@@ -62,7 +63,7 @@ class Strategy:
 
     @abc.abstractmethod
     def _sample(self, input_sample, num_samples,
-                num_params, k_choices, groups):
+                num_params, k_choices, num_groups):
         """Implement this in your class
 
         Arguments
@@ -74,8 +75,8 @@ class Strategy:
             The number of parameters
         k_choices : int
             The number of optimal trajectories
-        groups : tuple
-            A tuple of (numpy.ndarray, list)
+        num_groups : int
+            The number of groups
 
         Returns
         -------
@@ -85,7 +86,7 @@ class Strategy:
         pass
 
     def sample(self, input_sample, num_samples, num_params,
-               k_choices, groups):
+               k_choices, num_groups=None):
         """Computes the optimum k_choices of trajectories
         from the input_sample.
 
@@ -98,8 +99,8 @@ class Strategy:
             The number of parameters
         k_choices : int
             The number of optimal trajectories
-        groups : tuple
-            A tuple of (numpy.ndarray, list)
+        num_groups : int, default=None
+            The number of groups
 
         Returns
         -------
@@ -107,13 +108,9 @@ class Strategy:
         """
         self.run_checks(num_samples, k_choices)
         maximum_combo = self._sample(input_sample, num_samples,
-                                     num_params, k_choices, groups)
+                                     num_params, k_choices, num_groups)
 
         assert isinstance(maximum_combo, list)
-
-        num_groups = None
-        if groups is not None:
-            num_groups = groups[0].shape[1]
 
         output = self.compile_output(input_sample,
                                      num_samples,
@@ -241,7 +238,7 @@ class Strategy:
         return distance
 
     def compute_distance_matrix(self, input_sample, num_samples, num_params,
-                                groups=None,
+                                num_groups=None,
                                 local_optimization=False):
         """Computes the distance between each and every trajectory
 
@@ -260,8 +257,8 @@ class Strategy:
             The number of trajectories
         num_params : int
             The number of factors
-        groups : tuple, default=None
-            the mapping between factors and groups
+        num_groups : int, default=None
+            The number of groups
         local_optimization : bool, default=False
             If True, fills the lower triangle of the distance matrix
 
@@ -270,9 +267,7 @@ class Strategy:
         distance_matrix : numpy.ndarray
 
         """
-        num_groups = None
-        if groups:
-            num_groups = groups[0].shape[1]
+        if num_groups:
             self.check_input_sample(input_sample, num_groups, num_samples)
         else:
             self.check_input_sample(input_sample, num_params, num_samples)

--- a/SALib/sample/saltelli.py
+++ b/SALib/sample/saltelli.py
@@ -34,7 +34,7 @@ def sample(problem, N, calc_second_order=True):
         Dg = problem['num_vars']
     else:
         Dg = len(set(groups))
-        G, group_names = compute_groups_matrix(groups, D)
+        G, group_names = compute_groups_matrix(groups)
 
     # How many values of the Sobol sequence to skip
     skip_values = 1000

--- a/SALib/util/__init__.py
+++ b/SALib/util/__init__.py
@@ -157,9 +157,7 @@ def read_param_file(filename, delimiter=None):
         - bounds - a list of lists of lower and upper bounds
         - num_vars - a scalar indicating the number of variables
                      (the length of names)
-        - groups - a tuple containing i) a group matrix assigning parameters to
-                   groups
-                                      ii) a list of unique group names
+        - groups - a list of group names (strings) for each variable
         - dists - a list of distributions for the problem,
                     None if not specified or all uniform
 
@@ -208,9 +206,6 @@ def read_param_file(filename, delimiter=None):
                 else:
                     dists.append(row['dist'])
 
-    # group_matrix, group_names = compute_groups_from_parameter_file(
-    #     groups, num_vars)
-
     if groups == names:
         groups = None
     elif len(set(groups)) == 1:
@@ -226,7 +221,7 @@ def read_param_file(filename, delimiter=None):
             'groups': groups, 'dists': dists}
 
 
-def compute_groups_matrix(groups, num_vars):
+def compute_groups_matrix(groups):
     """Generate matrix which notes factor membership of groups
 
     Computes a k-by-g matrix which notes factor membership of groups
@@ -235,6 +230,11 @@ def compute_groups_matrix(groups, num_vars):
         g is the number of groups
     Also returns a g-length list of unique group_names whose positions
     correspond to the order of groups in the k-by-g matrix
+
+    Arguments
+    ---------
+    groups : list
+        Group names corresponding to each variable
 
     Returns
     -------
@@ -245,6 +245,8 @@ def compute_groups_matrix(groups, num_vars):
     if not groups:
         return None
 
+    num_vars = len(groups)
+    
     # Get a unique set of the group names
     unique_group_names = list(OrderedDict.fromkeys(groups))
     number_of_groups = len(unique_group_names)

--- a/tests/sample/morris/test_morris.py
+++ b/tests/sample/morris/test_morris.py
@@ -43,7 +43,7 @@ def test_group_in_param_file_read(setup_param_file_with_groups):
     parameter_file = setup_param_file_with_groups
     problem = read_param_file(parameter_file)
     groups, group_names = compute_groups_matrix(
-        problem['groups'], problem['num_vars'])
+        problem['groups'])
 
     assert_equal(problem['names'], ["Test 1", "Test 2", "Test 3"])
     assert_equal(groups, np.matrix('1,0;1,0;0,1', dtype=np.int))

--- a/tests/sample/morris/test_morris_strategies.py
+++ b/tests/sample/morris/test_morris_strategies.py
@@ -207,7 +207,7 @@ class TestLocallyOptimalStrategy:
 
         input_sample = _sample_groups(problem, N, num_levels, grid_jump)
 
-        groups = compute_groups_matrix(groups, num_params)
+        groups = compute_groups_matrix(groups)
 
         strategy = LocalOptimisation()
 

--- a/tests/sample/morris/test_morris_strategies.py
+++ b/tests/sample/morris/test_morris_strategies.py
@@ -4,7 +4,7 @@ from SALib.sample.morris import _sample_groups, SampleMorris
 from SALib.sample.morris.local import LocalOptimisation
 from SALib.sample.morris.brute import BruteForce
 
-from SALib.util import read_param_file, compute_groups_matrix
+from SALib.util import read_param_file
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
@@ -203,24 +203,23 @@ class TestLocallyOptimalStrategy:
         k_choices = 4
 
         num_params = problem['num_vars']
-        groups = problem['groups']
+
+        num_groups = len(set(problem['groups']))
 
         input_sample = _sample_groups(problem, N, num_levels, grid_jump)
-
-        groups = compute_groups_matrix(groups)
 
         strategy = LocalOptimisation()
 
         # From local optimal trajectories
         actual = strategy.find_local_maximum(input_sample, N, num_params,
-                                             k_choices, groups)
+                                             k_choices, num_groups)
 
         brute = BruteForce()
         desired = brute.brute_force_most_distant(input_sample,
                                                  N,
                                                  num_params,
                                                  k_choices,
-                                                 groups)
+                                                 num_groups)
         assert_equal(actual, desired)
 
 
@@ -233,7 +232,7 @@ class TestLocalMethods:
         strategy = LocalOptimisation()
 
         dist_matr = strategy.compute_distance_matrix(setup_input, 6, 2,
-                                                     groups=None,
+                                                     num_groups=None,
                                                      local_optimization=True)
         indices = (1, 3, 2)
         distance = strategy.sum_distances(indices, dist_matr)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -172,7 +172,7 @@ def test_compute_groups_from_parameter_file():
     Tests that a group file is read correctly
     '''
     actual_matrix, actual_unique_names = \
-        compute_groups_matrix(['Group 1', 'Group 2', 'Group 2'], 3)
+        compute_groups_matrix(['Group 1', 'Group 2', 'Group 2'])
 
     assert_equal(actual_matrix, np.matrix('1,0;0,1;0,1', dtype=np.int))
     assert_equal(actual_unique_names, ['Group 1', 'Group 2'])


### PR DESCRIPTION
Addresses #161, there was some confusion in the purpose and syntax of parameter groups.

* added a section to advanced readme
* fixed docstring for the `read_param_file()` function in `util/__init__.py`
* removed redundant input parameter `num_vars` from `compute_groups_matrix` function in the same file, and changed all calls to this function throughout. (The number of variables is always the length of the list of group names, which is the other input)

No changes to dependencies, so not sure why the dependency-ci error below.