### PR TITLE
bug fixes to FAST (#162)

### DIFF
--- a/SALib/analyze/fast.py
+++ b/SALib/analyze/fast.py
@@ -85,7 +85,7 @@ def analyze(problem, Y, M=4, print_to_console=False):
 
 def compute_first_order(outputs, N, M, omega):
     f = np.fft.fft(outputs)
-    Sp = np.power(np.absolute(f[np.arange(1, int(N / 2))]) / N, 2)
+    Sp = np.power(np.absolute(f[np.arange(1, math.ceil(N / 2))]) / N, 2)
     V = 2 * np.sum(Sp)
     D1 = 2 * np.sum(Sp[np.arange(1, M + 1) * int(omega) - 1])
     return D1 / V
@@ -93,7 +93,7 @@ def compute_first_order(outputs, N, M, omega):
 
 def compute_total_order(outputs, N, omega):
     f = np.fft.fft(outputs)
-    Sp = np.power(np.absolute(f[np.arange(1, int(N / 2))]) / N, 2)
+    Sp = np.power(np.absolute(f[np.arange(1, math.ceil(N / 2))]) / N, 2)
     V = 2 * np.sum(Sp)
     Dt = 2 * sum(Sp[np.arange(int(omega / 2))])
     return (1 - Dt / V)

--- a/SALib/analyze/fast.py
+++ b/SALib/analyze/fast.py
@@ -85,7 +85,7 @@ def analyze(problem, Y, M=4, print_to_console=False):
 
 def compute_first_order(outputs, N, M, omega):
     f = np.fft.fft(outputs)
-    Sp = np.power(np.absolute(f[np.arange(1, math.ceil(N / 2))]) / N, 2)
+    Sp = np.power(np.absolute(f[np.arange(1, int((N+1)/2))]) / N, 2)
     V = 2 * np.sum(Sp)
     D1 = 2 * np.sum(Sp[np.arange(1, M + 1) * int(omega) - 1])
     return D1 / V
@@ -93,7 +93,7 @@ def compute_first_order(outputs, N, M, omega):
 
 def compute_total_order(outputs, N, omega):
     f = np.fft.fft(outputs)
-    Sp = np.power(np.absolute(f[np.arange(1, math.ceil(N / 2))]) / N, 2)
+    Sp = np.power(np.absolute(f[np.arange(1, int((N+1)/2))]) / N, 2)
     V = 2 * np.sum(Sp)
     Dt = 2 * sum(Sp[np.arange(int(omega / 2))])
     return (1 - Dt / V)

--- a/SALib/sample/fast_sampler.py
+++ b/SALib/sample/fast_sampler.py
@@ -27,7 +27,7 @@ def sample(problem, N, M=4):
         Fourier series decomposition (default 4)
     """
 
-    if N < 4*M**2:
+    if N <= 4*M**2:
         raise ValueError("""
         Sample size N > 4M^2 is required. M=4 by default.""")
 


### PR DESCRIPTION
Addresses two bug fixes mentioned in #162 for FAST

- Sample size requirement should be N > 4M^2

- In `compute_first_order` and `compute_total_order` functions, the array length of `Sp` should use the `math.ceil` function instead of `int`, round up instead of down from `N/2`