### PR TITLE
remove quotes and commas from setup.cfg classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,14 +9,14 @@ description-file = README.md
 # Add here all kinds of additional classifiers as defined under
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 classifiers =
-    'Intended Audience :: End Users/Desktop',
-    'Intended Audience :: Developers',
-    'Intended Audience :: Science/Research',
-    'Operating System :: MacOS :: MacOS X',
-    'Operating System :: Microsoft :: Windows',
-    'Operating System :: POSIX',
-    'Programming Language :: Python',
-    'Topic :: Scientific/Engineering :: Mathematics',
+    Intended Audience :: End Users/Desktop
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Programming Language :: Python
+    Topic :: Scientific/Engineering :: Mathematics
 
 [entry_points]
 # Add here console scripts such as:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,7 @@ author-email = jdherman8@gmail.com
 license = MIT
 home-page = http://salib.github.io/SALib/
 description-file = README.md
-# Add here all kinds of additional classifiers as defined under
-# https://pypi.python.org/pypi?%3Aaction=list_classifiers
-classifiers =
+classifier = 
     Intended Audience :: End Users/Desktop
     Intended Audience :: Developers
     Intended Audience :: Science/Research


### PR DESCRIPTION
I think this will resolve the deployment error at the end of #162 ... looks like Travis does not expect quotes or commas anymore, and adds the quotes instead.

Edit: this is only a guess and might not be correct. Is there a way to see if it works without merging first?