### PR TITLE
in getting-started documentation, remove the keyword for calc_second_…

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -73,7 +73,7 @@ and copy/paste the code below.
     }
 
     # Generate samples
-    param_values = saltelli.sample(problem, 1000, calc_second_order=False)
+    param_values = saltelli.sample(problem, 1000)
 
     # Run model (example)
     Y = Ishigami.evaluate(param_values)


### PR DESCRIPTION
…order=False. This is default True, so the example will not run correctly because the analyze() setting does not match the sample() setting.