### PR TITLE
fix for 'one' instead of 'zero' in ValueError text

### DIFF
--- a/SALib/test_functions/Sobol_G.py
+++ b/SALib/test_functions/Sobol_G.py
@@ -21,7 +21,7 @@ def evaluate(values, a=None):
     gto = np.array(values) > 1
 
     if ltz.any() == True:
-        raise ValueError("Sobol G function called with values less than one")
+        raise ValueError("Sobol G function called with values less than zero")
     elif gto.any() == True:
         raise ValueError("Sobol G function called with values greater than one")
 


### PR DESCRIPTION
Hey,

Not much of an error, but could be helpful for a user to know that you meant 'zero' here :)

Have a nice day!