### PR TITLE
fix doc typo (default interference parameter)

### DIFF
--- a/SALib/analyze/rbd_fast.py
+++ b/SALib/analyze/rbd_fast.py
@@ -29,7 +29,7 @@ def analyze(problem, Y, X, M=10, print_to_console=False):
         A NumPy array containing the model inputs
     M : int
         The interference parameter, i.e., the number of harmonics to sum in
-        the Fourier series decomposition (default 4)
+        the Fourier series decomposition (default 10)
     print_to_console : bool
         Print results directly to console (default False)
 


### PR DESCRIPTION
Fix typo in RBD-fast docstring (see [issue 200](https://github.com/SALib/SALib/issues/200))