### PR TITLE
Fixes inconsistent use of grid_jump and delta in Morris implementations

### DIFF
--- a/SALib/analyze/morris.py
+++ b/SALib/analyze/morris.py
@@ -7,13 +7,13 @@ import numpy as np
 
 from . import common_args
 from ..util import read_param_file, compute_groups_matrix
+from ..sample.morris import compute_delta
 
 
 def analyze(problem, X, Y,
             num_resamples=1000,
             conf_level=0.95,
             print_to_console=False,
-            grid_jump=2,
             num_levels=4):
     """Perform Morris Analysis on model outputs.
 
@@ -36,9 +36,6 @@ def analyze(problem, X, Y,
         The confidence interval level (default 0.95)
     print_to_console : bool
         Print results directly to console (default False)
-    grid_jump : int
-        The grid jump size, must be identical to the value passed
-        to :func:`SALib.sample.morris.sample` (default 2)
     num_levels : int
         The number of grid levels, must be identical to the value
         passed to SALib.sample.morris (default 4)
@@ -66,10 +63,10 @@ def analyze(problem, X, Y,
 
     Examples
     --------
-    >>> X = morris.sample(problem, 1000, num_levels=4, grid_jump=2)
+    >>> X = morris.sample(problem, 1000, num_levels=4)
     >>> Y = Ishigami.evaluate(X)
     >>> Si = morris.analyze(problem, X, Y, conf_level=0.95,
-    >>>                     print_to_console=True, num_levels=4, grid_jump=2)
+    >>>                     print_to_console=True, num_levels=4)
 
     """
 
@@ -81,8 +78,7 @@ def analyze(problem, X, Y,
 
     # Assume that there are no groups
     groups = None
-
-    delta = grid_jump / (num_levels - 1)
+    delta = compute_delta(num_levels)
 
     num_vars = problem['num_vars']
 
@@ -235,7 +231,7 @@ def compute_elementary_effects(model_inputs, model_outputs, trajectory_size,
     trajectory_size
         a scalar indicating the number of rows in a trajectory
     delta : float
-        scaling factor computed from `grid_jump` and `num_levels`
+        scaling factor computed from `num_levels`
     '''
     num_vars = model_inputs.shape[1]
     num_rows = model_inputs.shape[0]
@@ -305,4 +301,4 @@ if __name__ == "__main__":
         X = X.reshape((len(X), 1))
 
     analyze(problem, X, Y, num_resamples=args.resamples, print_to_console=True,
-            num_levels=args.levels, grid_jump=args.grid_jump)
+            num_levels=args.levels)

--- a/SALib/plotting/morris.py
+++ b/SALib/plotting/morris.py
@@ -6,44 +6,21 @@ Created on 29 Jun 2015
 This module provides the basic infrastructure for plotting charts for the
 Method of Morris results
 
-The procedures should build upon and return an axes instance.
+The procedures should build upon and return an axes instance::
 
-Si = morris.analyze(problem, param_values, Y, conf_level=0.95, print_to_console=False, num_levels=10, grid_jump=5)
-p = morris.horizontal_bar_plot(Si)
-# set plot style etc.
+    import matplotlib.plot as plt
+    Si = morris.analyze(problem, param_values, Y, conf_level=0.95,
+                        print_to_console=False, num_levels=10)
+    p = morris.horizontal_bar_plot(Si)
+    # set plot style etc.
 
-fig, ax = plt.subplots(1, 1)
-my_plotter(ax, data1, data2, {'marker':'x'})
+    fig, ax = plt.subplots(1, 1)
+    my_plotter(ax, data1, data2, {'marker':'x'})
 
-p.show()
-
-def my_plotter(ax, data1, data2, param_dict):
-    A helper function to make a graph
-
-    Parameters
-    ax : Axes
-        The axes to draw to
-
-    data1 : array
-       The x data
-
-    data2 : array
-       The y data
-
-    param_dict : dict
-       Dictionary of kwargs to pass to ax.plot
-
-    Returns
-    out : list
-        list of artists added
-    """
-    out = ax.plot(data1, data2, **param_dict)
-    return out
-
+    p.show()
 '''
-
-import matplotlib.pyplot as plt
 import numpy as np
+
 
 def _sort_Si(Si, key, sortby='mu_star'):
     return np.array([Si[key][x] for x in np.argsort(Si[sortby])])
@@ -60,8 +37,6 @@ def horizontal_bar_plot(ax, Si, param_dict, sortby='mu_star', unit=''):
     '''
 
     assert sortby in ['mu_star', 'mu_star_conf', 'sigma', 'mu']
-
-    fig = ax.get_figure()
 
     # Sort all the plotted elements by mu_star (or optionally another
     # metric)
@@ -98,7 +73,7 @@ def covariance_plot(ax, Si, param_dict, unit=""):
         # sigma is not present if using morris groups
         y = Si['sigma']
         out = ax.scatter(Si['mu_star'], y, c=u'k', marker=u'o',
-                 **param_dict)
+                         **param_dict)
         ax.set_ylabel(r'$\sigma$')
 
         ax.set_xlim(0,)
@@ -118,7 +93,7 @@ def covariance_plot(ax, Si, param_dict, unit=""):
     else:
         y = Si['mu_star_conf']
         out = ax.scatter(Si['mu_star'], y, c=u'k', marker=u'o',
-                 **param_dict)
+                         **param_dict)
         ax.set_ylabel(r'$95\% CI$')
 
     ax.set_xlabel(r'$\mu^\star$ ' + unit)
@@ -137,7 +112,7 @@ def sample_histograms(fig, input_sample, problem, param_dict):
     framing = 101 + (num_vars * 10)
 
     # Find number of levels
-    num_levels = len(set(input_sample[:,1]))
+    num_levels = len(set(input_sample[:, 1]))
 
     out = []
 
@@ -154,13 +129,14 @@ def sample_histograms(fig, input_sample, problem, param_dict):
                        which='both',  # both major and minor ticks are affected
                        bottom='off',  # ticks along the bottom edge are off
                        top='off',  # ticks along the top edge are off
-                       labelbottom='off')  # labels along the bottom edge are off)
+                       labelbottom='off')  # labels along the bottom edge off)
         if variable > 0:
             ax.tick_params(axis='y',  # changes apply to the y-axis
-                           which='both',  # both major and minor ticks are affected
-                           labelleft='off')  # labels along the left edge are off)
+                           which='both',  # both major and minor ticks affected
+                           labelleft='off')  # labels along the left edge off)
 
     return out
+
 
 if __name__ == '__main__':
     pass

--- a/SALib/sample/morris/__init__.py
+++ b/SALib/sample/morris/__init__.py
@@ -152,10 +152,10 @@ def _sample_groups(problem, N, num_levels=4):
     group_membership, _ = compute_groups_matrix(problem['groups'])
 
     if group_membership is None:
-        raise ValueError("Please define the matrix group_membership.")
-    if not isinstance(group_membership, np.matrixlib.defmatrix.matrix):
-        raise TypeError("Matrix group_membership should be formatted \
-                         as a numpy matrix")
+        raise ValueError("Please define the 'group_membership' matrix")
+    if not isinstance(group_membership, np.ndarray):
+        raise TypeError("Argument 'group_membership' should be formatted \
+                         as a numpy ndarray")
 
     num_params = group_membership.shape[0]
     num_groups = group_membership.shape[1]
@@ -194,13 +194,13 @@ def generate_trajectory(group_membership, num_levels=4):
     num_groups = group_membership.shape[1]
 
     # Matrix B - size (g + 1) * g -  lower triangular matrix
-    B = np.matrix(np.tril(np.ones([num_groups + 1, num_groups],
-                                  dtype=int), -1))
+    B = np.tril(np.ones([num_groups + 1, num_groups],
+                        dtype=int), -1)
 
-    P_star = np.asmatrix(generate_p_star(num_groups))
+    P_star = generate_p_star(num_groups)
 
     # Matrix J - a (g+1)-by-num_params matrix of ones
-    J = np.matrix(np.ones((num_groups + 1, num_params)))
+    J = np.ones((num_groups + 1, num_params))
 
     # Matrix D* - num_params-by-num_params matrix which decribes whether
     # factors move up or down
@@ -218,9 +218,12 @@ def generate_trajectory(group_membership, num_levels=4):
 def compute_b_star(J, x_star, delta, B, G, P_star, D_star):
     """
     """
-    b_star = J[:, 0] * x_star + \
-        (delta / 2) * ((2 * B * (G * P_star).T - J)
-                       * D_star + J)
+    element_a = J[0, :] * x_star
+    element_b = (G @ P_star).T
+    element_c = 2 * B @ element_b
+    element_d = (element_c - J) @ D_star
+
+    b_star = element_a + (delta / 2) * (element_d + J)
     return b_star
 
 
@@ -256,18 +259,18 @@ def generate_x_star(num_params, num_levels):
 
     Returns
     -------
-    np.matrix
+    numpy.ndarray
         The initial starting positions of the trajectory
 
     """
-    x_star = np.zeros(num_params)
+    x_star = np.zeros((1, num_params))
     delta = compute_delta(num_levels)
     bound = 1 - delta
     grid = np.linspace(0, bound, 2)
 
     for i in range(num_params):
-        x_star[i] = rd.choice(grid)
-    return np.asmatrix(x_star)
+        x_star[0, i] = rd.choice(grid)
+    return x_star
 
 
 def compute_delta(num_levels):

--- a/SALib/sample/morris/__init__.py
+++ b/SALib/sample/morris/__init__.py
@@ -219,9 +219,9 @@ def compute_b_star(J, x_star, delta, B, G, P_star, D_star):
     """
     """
     element_a = J[0, :] * x_star
-    element_b = (G @ P_star).T
-    element_c = 2 * B @ element_b
-    element_d = (element_c - J) @ D_star
+    element_b = np.matmul(G, P_star).T
+    element_c = np.matmul(2 * B, element_b)
+    element_d = np.matmul((element_c - J), D_star)
 
     b_star = element_a + (delta / 2) * (element_d + J)
     return b_star

--- a/SALib/sample/morris/__init__.py
+++ b/SALib/sample/morris/__init__.py
@@ -47,8 +47,10 @@ except ImportError:
 else:
     _has_gurobi = True
 
+__all__ = ['sample']
 
-def sample(problem, N, num_levels, grid_jump, optimal_trajectories=None,
+
+def sample(problem, N, num_levels=4, optimal_trajectories=None,
            local_optimization=True):
     """Generate model inputs using the Method of Morris
 
@@ -67,10 +69,8 @@ def sample(problem, N, num_levels, grid_jump, optimal_trajectories=None,
         The problem definition
     N : int
         The number of trajectories to generate
-    num_levels : int
+    num_levels : int, default=4
         The number of grid levels
-    grid_jump : int
-        The grid jump size
     optimal_trajectories : int
         The number of optimal trajectories to sample (between 2 and N)
     local_optimization : bool, default=True
@@ -86,13 +86,10 @@ def sample(problem, N, num_levels, grid_jump, optimal_trajectories=None,
         of Morris. The resulting matrix has :math:`(G/D+1)*N/T` rows and
         :math:`D` columns, where :math:`D` is the number of parameters.
     """
-    if grid_jump >= num_levels:
-        raise ValueError("grid_jump must be less than num_levels")
-
     if problem.get('groups'):
-        sample = _sample_groups(problem, N, num_levels, grid_jump)
+        sample = _sample_groups(problem, N, num_levels)
     else:
-        sample = _sample_oat(problem, N, num_levels, grid_jump)
+        sample = _sample_oat(problem, N, num_levels)
 
     if optimal_trajectories:
 
@@ -106,7 +103,7 @@ def sample(problem, N, num_levels, grid_jump, optimal_trajectories=None,
     return sample
 
 
-def _sample_oat(problem, N, num_levels, grid_jump):
+def _sample_oat(problem, N, num_levels=4):
     """Generate trajectories without groups
 
     Arguments
@@ -115,54 +112,21 @@ def _sample_oat(problem, N, num_levels, grid_jump):
         The problem definition
     N : int
         The number of samples to generate
-    num_levels : int
+    num_levels : int, default=4
         The number of grid levels
-    grid_jump : int
-        The grid jump size
     """
+    group_membership = np.asmatrix(np.identity(problem['num_vars'],
+                                               dtype=int))
 
-    D = problem['num_vars']
-
-    # orientation matrix B: lower triangular (1) + upper triangular (-1)
-    B = np.tril(np.ones([D + 1, D], dtype=int), -1) + \
-        np.triu(-1 * np.ones([D + 1, D], dtype=int))
-
-    # grid step delta, and final sample matrix X
-    delta = grid_jump / (num_levels - 1)
-    X = np.zeros([N * (D + 1), D])
-
-    # Create N trajectories. Each trajectory contains D+1 parameter sets.
-    # (Starts at a base point, and then changes one parameter at a time)
-    for j in range(N):
-
-        # directions matrix DM - diagonal matrix of either +1 or -1
-        DM = np.diag([rd.choice([-1, 1]) for _ in range(D)])
-
-        # permutation matrix P
-        perm = rd.permutation(D)
-        P = np.zeros([D, D])
-        for i in range(D):
-            P[i, perm[i]] = 1
-
-        # starting point for this trajectory
-        x_base = np.zeros([D + 1, D])
-        for i in range(D):
-            x_base[:, i] = (
-                rd.choice(np.arange(num_levels - grid_jump))) \
-                / (num_levels - 1)
-
-        # Indices to be assigned to X, corresponding to this trajectory
-        index_list = np.arange(D + 1) + j * (D + 1)
-        delta_diag = np.diag([delta for _ in range(D)])
-
-        X[index_list, :] = 0.5 * \
-            (np.mat(B) * np.mat(P) * np.mat(DM) + 1) * \
-            np.mat(delta_diag) + np.mat(x_base)
-
-    return X
+    num_params = group_membership.shape[0]
+    sample = np.zeros((N * (num_params + 1), num_params))
+    sample = np.array([generate_trajectory(group_membership,
+                                           num_levels)
+                       for n in range(N)])
+    return sample.reshape((N * (num_params + 1), num_params))
 
 
-def _sample_groups(problem, N, num_levels, grid_jump):
+def _sample_groups(problem, N, num_levels=4):
     """Generate trajectories for groups
 
     Returns an :math:`N(g+1)`-by-:math:`k` array of `N` trajectories,
@@ -175,15 +139,16 @@ def _sample_groups(problem, N, num_levels, grid_jump):
         The problem definition
     N : int
         The number of trajectories to generate
-    num_levels : int
+    num_levels : int, default=4
         The number of grid levels
-    grid_jump : int
-        The grid jump size
 
     Returns
     -------
     numpy.ndarray
     """
+    if len(problem['groups']) != problem['num_vars']:
+        raise ValueError("Groups do not match to number of variables")
+
     group_membership, _ = compute_groups_matrix(problem['groups'])
 
     if group_membership is None:
@@ -196,13 +161,12 @@ def _sample_groups(problem, N, num_levels, grid_jump):
     num_groups = group_membership.shape[1]
     sample = np.zeros((N * (num_groups + 1), num_params))
     sample = np.array([generate_trajectory(group_membership,
-                                           num_levels,
-                                           grid_jump)
+                                           num_levels)
                        for n in range(N)])
     return sample.reshape((N * (num_groups + 1), num_params))
 
 
-def generate_trajectory(group_membership, num_levels, grid_jump):
+def generate_trajectory(group_membership, num_levels=4):
     """Return a single trajectory
 
     Return a single trajectory of size :math:`(g+1)`-by-:math:`k`
@@ -214,11 +178,8 @@ def generate_trajectory(group_membership, num_levels, grid_jump):
     ---------
     group_membership : np.ndarray
         a k-by-g matrix which notes factor membership of groups
-    num_levels : int
-        integer describing number of levels
-    grid_jump : int
-        recommended to be equal to :math:`p / (2(p-1))`
-        where :math:`p` is `num_levels`
+    num_levels : int, default=4
+        The number of levels in the grid
 
     Returns
     -------
@@ -245,7 +206,7 @@ def generate_trajectory(group_membership, num_levels, grid_jump):
     # factors move up or down
     D_star = np.diag([rd.choice([-1, 1]) for _ in range(num_params)])
 
-    x_star = np.asmatrix(generate_x_star(num_params, num_levels, grid_jump))
+    x_star = generate_x_star(num_params, num_levels)
 
     # Matrix B* - size (num_groups + 1) * num_params
     B_star = compute_b_star(J, x_star, delta, B,
@@ -280,7 +241,7 @@ def generate_p_star(num_groups):
     return p_star
 
 
-def generate_x_star(num_params, num_levels, grid_step):
+def generate_x_star(num_params, num_levels):
     """Generate an 1-by-num_params array to represent initial position for EE
 
     This should be a randomly generated array in the p level grid
@@ -292,19 +253,21 @@ def generate_x_star(num_params, num_levels, grid_step):
         The number of parameters (factors)
     num_levels : int
         The number of levels
-    grid_step : int
-        The grid step used
+
+    Returns
+    -------
+    np.matrix
+        The initial starting positions of the trajectory
 
     """
     x_star = np.zeros(num_params)
-
     delta = compute_delta(num_levels)
     bound = 1 - delta
-    grid = np.linspace(0, bound, grid_step)
+    grid = np.linspace(0, bound, 2)
 
     for i in range(num_params):
         x_star[i] = rd.choice(grid)
-    return x_star
+    return np.asmatrix(x_star)
 
 
 def compute_delta(num_levels):
@@ -384,8 +347,6 @@ if __name__ == "__main__":
         '-n', '--samples', type=int, required=True, help='Number of Samples')
     parser.add_argument('-l', '--levels', type=int, required=False,
                         default=4, help='Number of grid levels (Morris only)')
-    parser.add_argument('--grid-jump', type=int, required=False,
-                        default=2, help='Grid jump size (Morris only)')
     parser.add_argument('-k', '--k-optimal', type=int, required=False,
                         default=None,
                         help='Number of optimal trajectories (Morris only)')
@@ -399,7 +360,7 @@ if __name__ == "__main__":
 
     problem = read_param_file(args.paramfile)
     param_values = sample(problem, args.samples, args.levels,
-                          args.grid_jump, args.k_optimal, args.local)
+                          args.k_optimal, args.local)
 
     np.savetxt(args.output, param_values, delimiter=args.delimiter,
                fmt='%.' + str(args.precision) + 'e')

--- a/SALib/sample/morris/brute.py
+++ b/SALib/sample/morris/brute.py
@@ -114,12 +114,20 @@ class BruteForce(Strategy):
         '''
         Obtains scores from the distance_matrix for each pairwise combination
         held in the combos array
+
+        Arguments
+        ----------
+        combos : numpy.ndarray
+        pairwise : numpy.ndarray
+        distance_matrix : numpy.ndarray
         '''
         combos = np.array(combos)
         # Create a list of all pairwise combination for each combo in combos
         combo_list = combos[:, pairwise[:, ]]
-        all_distances = distance_matrix[[
-            combo_list[:, :, 1], combo_list[:, :, 0]]]
+
+        addresses = tuple([combo_list[:, :, 1], combo_list[:, :, 0]])
+
+        all_distances = distance_matrix[addresses]
         new_scores = np.sqrt(
             np.einsum('ij,ij->i', all_distances, all_distances))
         return new_scores

--- a/SALib/util/__init__.py
+++ b/SALib/util/__init__.py
@@ -246,7 +246,7 @@ def compute_groups_matrix(groups):
         return None
 
     num_vars = len(groups)
-    
+
     # Get a unique set of the group names
     unique_group_names = list(OrderedDict.fromkeys(groups))
     number_of_groups = len(unique_group_names)
@@ -259,7 +259,7 @@ def compute_groups_matrix(groups):
         group_index = indices[group_membership]
         output[parameter_row, group_index] = 1
 
-    return np.matrix(output), unique_group_names
+    return output, unique_group_names
 
 
 def requires_gurobipy(_has_gurobi):

--- a/examples/morris/morris.py
+++ b/examples/morris/morris.py
@@ -2,16 +2,13 @@ import sys
 
 from SALib.analyze import morris
 from SALib.sample.morris import sample
-from SALib.test_functions import Sobol_G, Ishigami
+from SALib.test_functions import Sobol_G
 from SALib.util import read_param_file
 from SALib.plotting.morris import horizontal_bar_plot, covariance_plot, \
-                                sample_histograms
+    sample_histograms
 import matplotlib.pyplot as plt
-import numpy as np
-
 
 sys.path.append('../..')
-
 
 # Read the parameter range file and generate samples
 problem = read_param_file('../../SALib/test_functions/params/Sobol_G.txt')
@@ -25,31 +22,32 @@ problem = read_param_file('../../SALib/test_functions/params/Sobol_G.txt')
 #             [-3.14159265359, 3.14159265359]]
 # }
 
-# Files with a 4th column for "group name" will be detected automatically, e.g.:
+# Files with a 4th column for "group name" will be detected automatically, e.g.
 # param_file = '../../SALib/test_functions/params/Ishigami_groups.txt'
 
 # Generate samples
-param_values = sample(problem, N=1000, num_levels=4, grid_jump=2, \
+param_values = sample(problem, N=1000, num_levels=4,
                       optimal_trajectories=None)
 
-# To use optimized trajectories (brute force method), give an integer value for optimal_trajectories
+# To use optimized trajectories (brute force method),
+# give an integer value for optimal_trajectories
 
 # Run the "model" -- this will happen offline for external models
 Y = Sobol_G.evaluate(param_values)
 
 # Perform the sensitivity analysis using the model output
 # Specify which column of the output file to analyze (zero-indexed)
-Si = morris.analyze(problem, param_values, Y, conf_level=0.95, 
+Si = morris.analyze(problem, param_values, Y, conf_level=0.95,
                     print_to_console=True,
-                    num_levels=4, grid_jump=2, num_resamples=100)
+                    num_levels=4, num_resamples=100)
 # Returns a dictionary with keys 'mu', 'mu_star', 'sigma', and 'mu_star_conf'
 # e.g. Si['mu_star'] contains the mu* value for each parameter, in the
 # same order as the parameter file
 
 fig, (ax1, ax2) = plt.subplots(1, 2)
-horizontal_bar_plot(ax1, Si,{}, sortby='mu_star', unit=r"tCO$_2$/year")
+horizontal_bar_plot(ax1, Si, {}, sortby='mu_star', unit=r"tCO$_2$/year")
 covariance_plot(ax2, Si, {}, unit=r"tCO$_2$/year")
 
 fig2 = plt.figure()
-sample_histograms(fig2, param_values, problem, {'color':'y'})
+sample_histograms(fig2, param_values, problem, {'color': 'y'})
 plt.show()

--- a/examples/morris/morris.sh
+++ b/examples/morris/morris.sh
@@ -8,8 +8,7 @@ python -m SALib.sample.morris \
        -o model_input.txt \
        --delimiter=' ' \
        --precision=8 \
-       --levels=10 \
-       --grid-jump=5
+       --levels=10
 
 # Options:
 # -p, --paramfile: Your parameter range file
@@ -34,7 +33,7 @@ python -m SALib.sample.morris \
 #                         Each variable will be perturbed by this number of levels
 #                         during each trajectory. Default is 2.
 #
-# -k, --k-optimal (optional): Number of optimal trajectories. 
+# -k, --k-optimal (optional): Number of optimal trajectories.
 #                             Default behavior uses vanilla OAT if --k-optimal is not specified
 
 # Run the model using the inputs sampled above, and save outputs
@@ -49,8 +48,7 @@ python -m SALib.analyze.morris \
        -c 0 \
        -X model_input.txt \
        -r 1000 \
-       -l=10 \
-       --grid-jump=5
+       -l=10
 
 # Options:
 # -p, --paramfile: Your parameter range file

--- a/tests/sample/morris/test_gurobi.py
+++ b/tests/sample/morris/test_gurobi.py
@@ -33,14 +33,12 @@ def test_optimal_sample_with_groups(setup_param_groups_prime):
 
     N = 10
     num_levels = 8
-    grid_jump = 4
     k_choices = 4
     num_params = problem['num_vars']
 
     sample = _sample_oat(problem,
                          N,
-                         num_levels,
-                         grid_jump)
+                         num_levels)
 
     strategy = GlobalOptimisation()
     actual = strategy.return_max_combo(sample,
@@ -81,7 +79,6 @@ def test_size_of_trajectories_with_groups(setup_param_groups_prime):
 
     N = 11
     num_levels = 8
-    grid_jump = 4
     k_choices = 4
     num_params = group_problem['num_vars']
 
@@ -90,8 +87,7 @@ def test_size_of_trajectories_with_groups(setup_param_groups_prime):
     # Test 1. dimensions of sample ignoring groups
     sample = _sample_oat(no_group_problem,
                          N,
-                         num_levels,
-                         grid_jump)
+                         num_levels)
 
     size_x, size_y = sample.shape
 
@@ -102,8 +98,7 @@ def test_size_of_trajectories_with_groups(setup_param_groups_prime):
 
     group_sample = _sample_groups(group_problem,
                                   N,
-                                  num_levels,
-                                  grid_jump)
+                                  num_levels)
 
     size_x, size_y = group_sample.shape
 
@@ -144,10 +139,9 @@ def test_optimal_combinations(setup_function):
     problem = read_param_file(param_file)
     num_params = problem['num_vars']
     num_levels = 10
-    grid_jump = num_levels / 2
     k_choices = 4
 
-    morris_sample = _sample_oat(problem, N, num_levels, grid_jump)
+    morris_sample = _sample_oat(problem, N, num_levels)
 
     global_strategy = GlobalOptimisation()
     actual = global_strategy.return_max_combo(morris_sample,
@@ -233,12 +227,11 @@ def test_optimised_trajectories_groups(setup_param_groups_prime):
     param_file = setup_param_groups_prime
     problem = read_param_file(param_file)
     num_levels = 4
-    grid_jump = num_levels / 2
     k_choices = 4
 
     num_params = problem['num_vars']
     groups = compute_groups_matrix(problem['groups'], num_params)
-    input_sample = _sample_groups(problem, N, num_levels, grid_jump)
+    input_sample = _sample_groups(problem, N, num_levels)
 
     # From gurobi optimal trajectories
     strategy = GlobalOptimisation()
@@ -266,10 +259,9 @@ def test_raise_error_if_k_gt_N(setup_function):
     param_file = setup_function
     problem = read_param_file(param_file)
     num_levels = 4
-    grid_jump = num_levels / 2
     k_choices = 6
 
-    morris_sample = _sample_oat(problem, N, num_levels, grid_jump)
+    morris_sample = _sample_oat(problem, N, num_levels)
 
     with raises(ValueError):
         _compute_optimised_trajectories(problem,

--- a/tests/sample/morris/test_morris.py
+++ b/tests/sample/morris/test_morris.py
@@ -48,7 +48,7 @@ def test_group_in_param_file_read(setup_param_file_with_groups):
         problem['groups'])
 
     assert_equal(problem['names'], ["Test 1", "Test 2", "Test 3"])
-    assert_equal(groups, np.matrix('1,0;1,0;0,1', dtype=np.int))
+    assert_equal(groups, np.array([[1, 0], [1, 0], [0, 1]], dtype=np.int))
     assert_equal(group_names, ['Group 1', 'Group 2'])
 
 
@@ -170,13 +170,13 @@ class TestGroupSampleGeneration:
         k = 3
         g = 2
 
-        x_star = np.matrix(np.array([1. / 3, 1. / 3, 0.]))
-        J = np.matrix(np.ones((g + 1, k)))
-        G = np.matrix('1,0;0,1;0,1')
-        D_star = np.matrix('1,0,0;0,-1,0;0,0,1')
-        P_star = np.matrix('1,0;0,1')
+        x_star = np.array([[1. / 3, 1. / 3, 0.]])
+        J = np.ones((g + 1, k))
+        G = np.array([[1, 0], [0, 1], [0, 1]])
+        D_star = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
+        P_star = np.array([[1, 0], [0, 1]])
         delta = 2. / 3
-        B = np.matrix(np.tril(np.ones([g + 1, g], dtype=int), -1))
+        B = np.tril(np.ones([g + 1, g], dtype=int), -1)
 
         desired = np.array([[1. / 3, 1, 0], [1, 1, 0], [1, 1. / 3, 2. / 3]])
 
@@ -192,5 +192,5 @@ class TestGroupSampleGeneration:
         np.random.seed(10)
         actual = generate_x_star(num_params, num_levels)
         print(actual)
-        expected = np.matrix([0.333333, 0.333333, 0., 0.333333])
+        expected = np.array([[0.333333, 0.333333, 0., 0.333333]])
         assert_allclose(actual, expected, rtol=1e-05)

--- a/tests/sample/morris/test_morris_strategies.py
+++ b/tests/sample/morris/test_morris_strategies.py
@@ -109,13 +109,10 @@ class TestSharedMethods:
         input_1 = np.matrix([[0, 1 / 3.], [0, 1.]], dtype=np.float32)
         input_3 = np.matrix([[2 / 3., 0], [2 / 3., 2 / 3.],
                              [0, 2 / 3.]], dtype=np.float32)
-        try:
-            strategy.compute_distance(input_1, input_3, 2)
-        except:
-            pass
-        else:
-            raise AssertionError(
-                "Different size matrices did not trigger error")
+        with raises(ValueError) as err:
+            strategy.compute_distance(input_1, input_3)
+
+        assert "Input matrices are different sizes" in str(err)
 
     def test_compute_distance_matrix(self, strategy, setup_input):
         '''
@@ -207,13 +204,12 @@ class TestLocallyOptimalStrategy:
         param_file = setup_param_groups_prime
         problem = read_param_file(param_file)
         num_levels = 4
-        grid_jump = num_levels / 2
 
         np.random.seed(12345)
-        expected = _sample_groups(problem, N, num_levels, grid_jump)
+        expected = _sample_groups(problem, N, num_levels)
 
         np.random.seed(12345)
-        actual = _sample_groups(problem, N, num_levels, grid_jump)
+        actual = _sample_groups(problem, N, num_levels)
 
         assert_equal(actual, expected)
 
@@ -236,14 +232,13 @@ class TestLocallyOptimalStrategy:
         param_file = setup_param_groups_prime
         problem = read_param_file(param_file)
         num_levels = 4
-        grid_jump = num_levels / 2
         k_choices = 4
 
         num_params = problem['num_vars']
 
         num_groups = len(set(problem['groups']))
 
-        input_sample = _sample_groups(problem, N, num_levels, grid_jump)
+        input_sample = _sample_groups(problem, N, num_levels)
 
         local = LocalOptimisation()
 

--- a/tests/sample/morris/test_morris_strategies.py
+++ b/tests/sample/morris/test_morris_strategies.py
@@ -89,26 +89,26 @@ class TestSharedMethods:
         '''
         Tests the computation of the distance of two trajectories
         '''
-        input_1 = np.matrix(
+        input_1 = np.array(
             [[0, 1 / 3.], [0, 1.], [2 / 3., 1.]], dtype=np.float32)
-        input_3 = np.matrix([[2 / 3., 0], [2 / 3., 2 / 3.],
-                             [0, 2 / 3.]], dtype=np.float32)
+        input_3 = np.array([[2 / 3., 0], [2 / 3., 2 / 3.],
+                            [0, 2 / 3.]], dtype=np.float32)
         output = strategy.compute_distance(input_1, input_3)
         assert_allclose(output, 6.18, atol=1e-2)
 
     def test_distance_of_identical_matrices_is_min(self, strategy):
-        input_1 = np.matrix([[1., 1.],
-                             [1., 0.33333333],
-                             [0.33333333, 0.33333333]])
+        input_1 = np.array([[1., 1.],
+                            [1., 0.33333333],
+                            [0.33333333, 0.33333333]])
         input_2 = input_1.copy()
         actual = strategy.compute_distance(input_1, input_2)
         desired = 0
         assert_allclose(actual, desired, atol=1e-2)
 
     def test_distance_fail_with_difference_size_ip(self, strategy):
-        input_1 = np.matrix([[0, 1 / 3.], [0, 1.]], dtype=np.float32)
-        input_3 = np.matrix([[2 / 3., 0], [2 / 3., 2 / 3.],
-                             [0, 2 / 3.]], dtype=np.float32)
+        input_1 = np.array([[0, 1 / 3.], [0, 1.]], dtype=np.float32)
+        input_3 = np.array([[2 / 3., 0], [2 / 3., 2 / 3.],
+                            [0, 2 / 3.]], dtype=np.float32)
         with raises(ValueError) as err:
             strategy.compute_distance(input_1, input_3)
 

--- a/tests/test_analyze_morris.py
+++ b/tests/test_analyze_morris.py
@@ -169,9 +169,10 @@ def test_compute_grouped_elementary_effects():
     problem = {'names': ['1', '2', '3', '4', '5', '6', '7', '8',
                          '9', '10', '11', '12', '13', '14', '15'],
                'bounds': [[]],
-               'groups': (np.matrix('0,0,0,0,0,0,0,0,1,0,1,1,1,1,1;1,1,1,\
-                                     1,1,1,1,1,0,1,0,0,0,0,0'),
-                          ['gp1', 'gp2']),
+               'groups':
+               (np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1],
+                          [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0]]),
+                ['gp1', 'gp2']),
                'num_vars': 15
                }
     ee = compute_elementary_effects(model_inputs, model_results, 3, 2. / 3)
@@ -270,7 +271,7 @@ def test_compute_grouped_mu_star():
     Computes mu_star for 3 variables grouped into 2 groups
     There are six trajectories.
     '''
-    group_matrix = np.matrix('1,0;0,1;0,1', dtype=np.int)
+    group_matrix = np.array([[1, 0], [0, 1], [0, 1]], dtype=np.int)
     ee = np.array([[2.52, 2.01, 2.30, -0.66, -0.93, -1.30],
                    [-2.00, 0.13, -0.80, 0.25, -0.02, 0.51],
                    [2.00, -0.13, 0.80, -0.25, 0.02, -0.51]])
@@ -294,7 +295,7 @@ def test_sigma_returned_for_groups_with_only_one_param():
     An NA should be returned for all other groups (as opposed to 0, which could
     confuse plotting.morris)
     '''
-    group_matrix = np.matrix('1,0;0,1;0,1', dtype=np.int)
+    group_matrix = np.array([[1, 0], [0, 1], [0, 1]], dtype=np.int)
     ee = np.array([[2.52, 2.01, 2.30, -0.66, -0.93, -1.30],
                    [-2.00, 0.13, -0.80, 0.25, -0.02, 0.51],
                    [2.00, -0.13, 0.80, -0.25, 0.02, -0.51]])

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -35,20 +35,22 @@ def set_seed():
 class TestMorris:
 
     def test_regression_morris_vanilla(self, set_seed):
+        """Note that this is a poor estimate of the Ishigami
+        function.
+        """
         set_seed
         param_file = 'SALib/test_functions/params/Ishigami.txt'
         problem = read_param_file(param_file)
-        param_values = sample(problem=problem, N=10000,
-                              num_levels=4, grid_jump=2,
+        param_values = sample(problem, 10000, 4,
                               optimal_trajectories=None)
 
         Y = Ishigami.evaluate(param_values)
 
         Si = morris.analyze(problem, param_values, Y,
                             conf_level=0.95, print_to_console=False,
-                            num_levels=4, grid_jump=2)
+                            num_levels=4)
 
-        assert_allclose(Si['mu_star'], [7.701555, 7.875, 6.288788],
+        assert_allclose(Si['mu_star'], [7.536586, 7.875, 6.308785],
                         atol=0, rtol=1e-5)
 
     def test_regression_morris_groups(self, set_seed):
@@ -57,14 +59,14 @@ class TestMorris:
         problem = read_param_file(param_file)
 
         param_values = sample(problem=problem, N=10000,
-                              num_levels=4, grid_jump=2,
+                              num_levels=4,
                               optimal_trajectories=None)
 
         Y = Ishigami.evaluate(param_values)
 
         Si = morris.analyze(problem, param_values, Y,
                             conf_level=0.95, print_to_console=False,
-                            num_levels=4, grid_jump=2)
+                            num_levels=4)
 
         assert_allclose(Si['mu_star'], [7.610322, 10.197014],
                         atol=0, rtol=1e-5)
@@ -76,7 +78,7 @@ class TestMorris:
         problem = read_param_file(param_file)
 
         param_values = sample(problem=problem, N=50,
-                              num_levels=4, grid_jump=2,
+                              num_levels=4,
                               optimal_trajectories=6,
                               local_optimization=False)
 
@@ -84,7 +86,7 @@ class TestMorris:
 
         Si = morris.analyze(problem, param_values, Y,
                             conf_level=0.95, print_to_console=False,
-                            num_levels=4, grid_jump=2)
+                            num_levels=4)
 
         assert_allclose(Si['mu'], [9.786986, np.NaN],
                         atol=0, rtol=1e-5)
@@ -101,7 +103,7 @@ class TestMorris:
         problem = read_param_file(param_file)
 
         param_values = sample(problem=problem, N=500,
-                              num_levels=4, grid_jump=2,
+                              num_levels=4,
                               optimal_trajectories=20,
                               local_optimization=True)
 
@@ -109,7 +111,7 @@ class TestMorris:
 
         Si = morris.analyze(problem, param_values, Y,
                             conf_level=0.95, print_to_console=False,
-                            num_levels=4, grid_jump=2)
+                            num_levels=4)
 
         assert_allclose(Si['mu_star'],
                         [13.95285, 7.875],
@@ -122,25 +124,24 @@ class TestMorris:
         Uses brute force approach
 
         Note that the relative tolerance is set to a very high value
-        (default is 1e-05) due to the coarse nature of the num_levels
-        and grid_jump.
+        (default is 1e-05) due to the coarse nature of the num_levels.
         '''
         set_seed
         param_file = 'SALib/test_functions/params/Ishigami.txt'
         problem = read_param_file(param_file)
         param_values = sample(problem=problem, N=20,
-                              num_levels=4, grid_jump=2,
+                              num_levels=4,
                               optimal_trajectories=9,
-                              local_optimization=False)
+                              local_optimization=True)
 
         Y = Ishigami.evaluate(param_values)
 
         Si = morris.analyze(problem, param_values, Y,
                             conf_level=0.95, print_to_console=False,
-                            num_levels=4, grid_jump=2)
+                            num_levels=4)
 
         assert_allclose(Si['mu_star'],
-                        [9.786986e+00, 7.875000e+00, 2.984617e-12],
+                        [9.786986e+00, 7.875000e+00, 1.388621],
                         atol=0,
                         rtol=1e-5)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -174,5 +174,6 @@ def test_compute_groups_from_parameter_file():
     actual_matrix, actual_unique_names = \
         compute_groups_matrix(['Group 1', 'Group 2', 'Group 2'])
 
-    assert_equal(actual_matrix, np.matrix('1,0;0,1;0,1', dtype=np.int))
+    assert_equal(actual_matrix, np.array(
+        [[1, 0], [0, 1], [0, 1]], dtype=np.int))
     assert_equal(actual_unique_names, ['Group 1', 'Group 2'])


### PR DESCRIPTION
Fixes #209 

**This changes the interface to the morris method - removing an argument.  I haven't used Deprecation warnings, and we should decide what to do before merging/releasing this.**

* provides default value for `levels` parameter (4)
* removes the `grid_jump` parameter from sample and analyze implementations of Morris.  The code now automatically calculates delta from the number of levels and this removes the need for a grid_jump parameter
* removed the duplicate implementation of Morris in preference of the (better tested) groups method, which is overridden by parameters when not using groups.