### PR TITLE
Travis: don't use python system site packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 sudo: false
 language: python
-virtualenv:
-  system_site_packages: true
 env:
   matrix:
-  - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
-  - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
+  - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true"
   - DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
 
 matrix:
   allow_failures:
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.8-dev" COVERAGE="false"
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@ sudo: false
 language: python
 env:
   matrix:
-  - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true"
-  - DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
-
-matrix:
+  - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
+  - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
   allow_failures:
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.8-dev" COVERAGE="false"
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ env:
   matrix:
   - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
   - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
+  - DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
+  - DISTRIB="conda" PYTHON_VERSION="3.8-dev" COVERAGE="false"
+matrix:
   allow_failures:
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.8-dev" COVERAGE="false"
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ env:
   - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
   - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
   - DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
-  - DISTRIB="conda" PYTHON_VERSION="3.8-dev" COVERAGE="false"
+  - DISTRIB="conda" PYTHON_VERSION="3.8" COVERAGE="false"
 matrix:
   allow_failures:
-    - env: DISTRIB="conda" PYTHON_VERSION="3.8-dev" COVERAGE="false"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.8" COVERAGE="false"
 addons:
   apt:
     packages:


### PR DESCRIPTION
Travis have updated the system version of Python that they use and this has caused our tests to fail.