### PR TITLE
Improved efficiency of summing distances in local optimization

### DIFF
--- a/src/SALib/sample/morris/local.py
+++ b/src/SALib/sample/morris/local.py
@@ -108,11 +108,9 @@ class LocalOptimisation(Strategy):
         are only used in a relative way. Purely summing distances would lead
         to the same result, at a perhaps quicker rate.
         """
-        combs_tup = np.array(tuple(combinations(indices, 2)))
+        combs_tup = tuple(combinations(indices, 2))
 
-        # Put indices from tuples into two-dimensional array.
-        combs = np.array([[i[0] for i in combs_tup],
-                          [i[1] for i in combs_tup]])
+        combs = np.array(tuple(zip(*combs_tup)))
 
         # Calculate distance (vectorized)
         dist = np.sqrt(


### PR DESCRIPTION
I did some profiling on a slightly modified morris sample example (master/examples/morris/morris.py). 
Only change I made to the example:

```
param_values = sample(problem, N=80, grid_jump=2, num_levels=4,
                      optimal_trajectories=79)
```

The main bottleneck is in `sum_distances` within `LocalOptimisation`. My laptop originally spent 85 seconds in this function and with this improvement it spent 44 seconds, a near 50% speed gain! 

Main culprits were the unnecessary list comprehensions, even though a call to zip suffices here.
Code is also slightly cleaner now, in my opinion :-)

Profiling was done in Spyder, I added the profiling files if you are interested.
