### PR TITLE
Morris - Minor performance enhancements

### DIFF
--- a/src/SALib/plotting/morris.py
+++ b/src/SALib/plotting/morris.py
@@ -120,7 +120,7 @@ def sample_histograms(fig, input_sample, problem, param_dict):
         ax = fig.add_subplot(framing + variable)
         out.append(ax.hist(input_sample[:, variable],
                            bins=num_levels,
-                           normed=False,
+                           density=False,
                            label=None,
                            **param_dict))
 

--- a/src/SALib/sample/morris/__init__.py
+++ b/src/SALib/sample/morris/__init__.py
@@ -204,7 +204,7 @@ def generate_trajectory(group_membership, num_levels=4):
 
     # Matrix D* - num_params-by-num_params matrix which decribes whether
     # factors move up or down
-    D_star = np.diag([rd.choice([-1, 1]) for _ in range(num_params)])
+    D_star = np.diag(rd.choice([-1, 1], num_params))
 
     x_star = generate_x_star(num_params, num_levels)
 
@@ -268,8 +268,8 @@ def generate_x_star(num_params, num_levels):
     bound = 1 - delta
     grid = np.linspace(0, bound, 2)
 
-    for i in range(num_params):
-        x_star[0, i] = rd.choice(grid)
+    x_star[0, :] = rd.choice(grid, num_params)
+
     return x_star
 
 
@@ -285,7 +285,7 @@ def compute_delta(num_levels):
     -------
     float
     """
-    return float(num_levels) / (2 * (num_levels - 1))
+    return num_levels / (2.0 * (num_levels - 1))
 
 
 def _compute_optimised_trajectories(problem, input_sample, N, k_choices,

--- a/src/SALib/sample/morris/__init__.py
+++ b/src/SALib/sample/morris/__init__.py
@@ -119,7 +119,6 @@ def _sample_oat(problem, N, num_levels=4):
                                                dtype=int))
 
     num_params = group_membership.shape[0]
-    sample = np.zeros((N * (num_params + 1), num_params))
     sample = np.array([generate_trajectory(group_membership,
                                            num_levels)
                        for n in range(N)])
@@ -220,10 +219,10 @@ def compute_b_star(J, x_star, delta, B, G, P_star, D_star):
     """
     element_a = J[0, :] * x_star
     element_b = np.matmul(G, P_star).T
-    element_c = np.matmul(2 * B, element_b)
+    element_c = np.matmul(2.0 * B, element_b)
     element_d = np.matmul((element_c - J), D_star)
 
-    b_star = element_a + (delta / 2) * (element_d + J)
+    b_star = element_a + (delta / 2.0) * (element_d + J)
     return b_star
 
 

--- a/src/SALib/sample/morris/brute.py
+++ b/src/SALib/sample/morris/brute.py
@@ -88,15 +88,16 @@ class BruteForce(Strategy):
 
         counter = 0
         # Generate a list of all the possible combinations
-        combo_gen = combinations(list(range(num_samples)), k_choices)
+        combo_gen = combinations(range(num_samples), k_choices)
         scores = np.zeros(number_of_combinations, dtype=np.float32)
         # Generate the pairwise indices once
         pairwise = np.array(
-            [y for y in combinations(list(range(k_choices)), 2)])
+            [y for y in combinations(range(k_choices), 2)])
 
+        mappable = self.mappable
         for combos in self.grouper(chunk, combo_gen):
             scores[(counter * chunk):((counter + 1) * chunk)] \
-                = self.mappable(combos, pairwise, distance_matrix)
+                = mappable(combos, pairwise, distance_matrix)
             counter += 1
         return scores
 
@@ -125,7 +126,7 @@ class BruteForce(Strategy):
         # Create a list of all pairwise combination for each combo in combos
         combo_list = combos[:, pairwise[:, ]]
 
-        addresses = tuple([combo_list[:, :, 1], combo_list[:, :, 0]])
+        addresses = [combo_list[:, :, 1], combo_list[:, :, 0]]
 
         all_distances = distance_matrix[addresses]
         new_scores = np.sqrt(
@@ -150,7 +151,7 @@ class BruteForce(Strategy):
 
         index_of_maximum = int(scores.argmax())
         maximum_combo = self.nth(combinations(
-            list(range(N)), k_choices), index_of_maximum, None)
+            range(N), k_choices), index_of_maximum, None)
         return sorted(maximum_combo)
 
     @staticmethod

--- a/src/SALib/sample/morris/local.py
+++ b/src/SALib/sample/morris/local.py
@@ -53,13 +53,11 @@ class LocalOptimisation(Strategy):
             indices_list = []
             row_maxima_i = maxima_template.copy()
 
-            row_nr = 0
-            for row in distance_matrix:
+            for row_nr, row in enumerate(distance_matrix):
                 indices = tuple(row.argsort()[-i:][::-1]) + (row_nr,)
                 row_maxima_i[row_nr] = self.sum_distances(
                     indices, distance_matrix)
                 indices_list.append(indices)
-                row_nr += 1
 
             # Find the indices belonging to the maximum distance
             i_max_ind = self.get_max_sum_ind(indices_list, row_maxima_i, i, 0)

--- a/src/SALib/sample/morris/local.py
+++ b/src/SALib/sample/morris/local.py
@@ -47,10 +47,11 @@ class LocalOptimisation(Strategy):
         tot_indices_list = []
         tot_max_array = np.zeros(k_choices - 1)
 
+        maxima_template = np.zeros(len(distance_matrix))
         # Loop over `k_choices`, i starts at 1
         for i in range(1, k_choices):
             indices_list = []
-            row_maxima_i = np.zeros(len(distance_matrix))
+            row_maxima_i = maxima_template.copy()
 
             row_nr = 0
             for row in distance_matrix:
@@ -71,9 +72,11 @@ class LocalOptimisation(Strategy):
             while m <= k_choices - i - 1:
                 m_ind = self.add_indices(m_max_ind, distance_matrix)
 
-                m_maxima = np.zeros(len(m_ind))
+                len_m_ind = len(m_ind)
 
-                for n in range(0, len(m_ind)):
+                m_maxima = np.zeros(len_m_ind)
+
+                for n in range(len_m_ind):
                     m_maxima[n] = self.sum_distances(m_ind[n], distance_matrix)
 
                 m_max_ind = self.get_max_sum_ind(m_ind, m_maxima, i, m)
@@ -86,7 +89,7 @@ class LocalOptimisation(Strategy):
 
         tot_max = self.get_max_sum_ind(
             tot_indices_list, tot_max_array, "tot", "tot")
-        return sorted(list(tot_max))
+        return sorted(tot_max)
 
     def sum_distances(self, indices, distance_matrix):
         """Calculate combinatorial distance between a select group of
@@ -141,7 +144,7 @@ class LocalOptimisation(Strategy):
             raise ValueError(msg.format(
                 len(indices_list), len(distances), i, m))
 
-        max_index = tuple(distances.argsort()[-1:][::-1])
+        max_index = distances.argsort()[-1:][::-1]
         return indices_list[max_index[0]]
 
     def add_indices(self, indices, distance_matrix):
@@ -159,7 +162,7 @@ class LocalOptimisation(Strategy):
 
         '''
         list_new_indices = []
-        for i in range(0, len(distance_matrix)):
+        for i in range(len(distance_matrix)):
             if i not in indices:
                 list_new_indices.append(indices + (i,))
         return list_new_indices

--- a/src/SALib/test_functions/Sobol_G.py
+++ b/src/SALib/test_functions/Sobol_G.py
@@ -11,28 +11,27 @@ import numpy as np
 # x4: 0.0072
 # x5-x8: 0.0001
 def evaluate(values, a=None):
-
     if type(values) != np.ndarray:
         raise TypeError("The argument `values` must be a numpy ndarray")
     if a is None:
         a = [0, 1, 4.5, 9, 99, 99, 99, 99]
 
-    ltz = np.array(values) < 0
-    gto = np.array(values) > 1
+    ltz = values < 0
+    gto = values > 1
 
     if ltz.any() == True:
         raise ValueError("Sobol G function called with values less than zero")
     elif gto.any() == True:
         raise ValueError("Sobol G function called with values greater than one")
 
-    Y = np.zeros([values.shape[0]])
+    Y = np.ones([values.shape[0]])
 
+    len_a = len(a)
     for i, row in enumerate(values):
-        Y[i] = 1.0
-
-        for j in range(len(a)):
+        for j in range(len_a):
             x = row[j]
-            Y[i] *= (abs(4 * x - 2) + a[j]) / (1 + a[j])
+            a_j = a[j]
+            Y[i] *= (np.abs(4 * x - 2) + a_j) / (1 + a_j)
 
     return Y
 


### PR DESCRIPTION
Minor changes to improve computational time performance.

Benchmarking using the package example for the Morris method shows decrease in runtime from 2.64 seconds to 1.95 seconds (~25% improvement).

All tests passed and output remains the same.

Further improvements possible by moving performance critical code to Cython or Numba as discussed [here](https://github.com/SALib/SALib/issues/234#issuecomment-500762392).
