### PR TITLE
Remove duplicated CLI options

### DIFF
--- a/src/SALib/analyze/delta.py
+++ b/src/SALib/analyze/delta.py
@@ -153,8 +153,8 @@ def sobol_first_conf(Y, X, m, num_resamples, conf_level):
 
 
 def cli_parse(parser):
-    parser.add_argument('-X', '--model-input-file', type=str,
-                        required=True, default=None,
+    parser.add_argument('-X', '--model-input-file', type=str, required=True,
+                        default=None,
                         help='Model input file')
     parser.add_argument('-r', '--resamples', type=int, required=False,
                         default=10,

--- a/src/SALib/analyze/fast.py
+++ b/src/SALib/analyze/fast.py
@@ -104,10 +104,8 @@ def compute_total_order(outputs, N, omega):
     return (1 - Dt / V)
 
 
-def cli_parse(parser):
-    # No additional arguments required for FAST
-    # This method is required to make sure tests pass.
-    return parser
+# No additional arguments required for FAST
+cli_parse = None
 
 
 def cli_action(args):

--- a/src/SALib/sample/common_args.py
+++ b/src/SALib/sample/common_args.py
@@ -12,19 +12,21 @@ def setup(parser):
     ----------
     Updated argparse object
     """
-    parser.add_argument(
-        '-p', '--paramfile', type=str, required=True,
-        help='Parameter Range File')
-    parser.add_argument(
-        '-o', '--output', type=str, required=True, help='Output File')
-    parser.add_argument(
-        '-s', '--seed', type=int, required=False, default=None,
-        help='Random Seed')
-    parser.add_argument(
-        '--delimiter', type=str, required=False, default=' ',
-        help='Column delimiter')
+    parser.add_argument('-n', '--samples', type=int, required=True,
+                        help='Number of Samples')
+    parser.add_argument('-p', '--paramfile', type=str, required=True,
+                        help='Parameter Range File')
+    parser.add_argument('-o', '--output', type=str, required=True, 
+                        help='Output File')
+    parser.add_argument('-s', '--seed', type=int, required=False, 
+                        default=None,
+                        help='Random Seed')
+    parser.add_argument('--delimiter', type=str, required=False,
+                        default=' ',
+                        help='Column delimiter')
     parser.add_argument('--precision', type=int, required=False,
-                        default=8, help='Output floating-point precision')
+                        default=8,
+                        help='Output floating-point precision')
 
     return parser
 

--- a/src/SALib/sample/fast_sampler.py
+++ b/src/SALib/sample/fast_sampler.py
@@ -80,9 +80,6 @@ def cli_parse(parser):
     ----------
     Updated argparse object
     """
-    parser.add_argument('-n', '--samples', type=int, required=True,
-                        help='Number of Samples')
-
     parser.add_argument('-M', '--m-coef', type=int, required=False, default=4,
                         help='M coefficient, default 4', dest='M')
     return parser

--- a/src/SALib/sample/fast_sampler.py
+++ b/src/SALib/sample/fast_sampler.py
@@ -12,7 +12,7 @@ def sample(problem, N, M=4, seed=None):
     """Generate model inputs for the Fourier Amplitude Sensitivity Test (FAST).
 
     Returns a NumPy matrix containing the model inputs required by the Fourier
-    Amplitude sensitivity test.  The resulting matrix contains N rows and D
+    Amplitude sensitivity test.  The resulting matrix contains N * D rows and D
     columns, where D is the number of parameters.  The samples generated are
     intended to be used by :func:`SALib.analyze.fast.analyze`.
 

--- a/src/SALib/sample/ff.py
+++ b/src/SALib/sample/ff.py
@@ -113,23 +113,8 @@ def sample(problem, seed=None):
     return sample
 
 
-def cli_parse(parser):
-    """Add method specific options to CLI parser.
-
-    Parameters
-    ----------
-    parser : argparse object
-
-    Returns
-    ----------
-    Updated argparse object
-    """
-    parser.add_argument('-n', '--samples', type=int, required=True,
-                        help='Number of Samples')
-
-    parser.add_argument('-M', type=int, required=False, default=4,
-                        help='M coefficient, default 4')
-    return parser
+# No additional CLI options
+cli_parse = None
 
 
 def cli_action(args):

--- a/src/SALib/sample/finite_diff.py
+++ b/src/SALib/sample/finite_diff.py
@@ -59,8 +59,6 @@ def cli_parse(parser):
     parser.add_argument('-d', '--delta', type=float,
                         required=False, default=0.01,
                         help='Finite difference step size (percent)')
-    parser.add_argument('-n', '--samples', type=int,
-                        required=True, help='Number of Samples')
     return parser
 
 

--- a/src/SALib/sample/latin.py
+++ b/src/SALib/sample/latin.py
@@ -43,20 +43,8 @@ def sample(problem, N, seed=None):
     return result
 
 
-def cli_parse(parser):
-    """Add method specific options to CLI parser.
-
-    Parameters
-    ----------
-    parser : argparse object
-
-    Returns
-    ----------
-    Updated argparse object
-    """
-    parser.add_argument('-n', '--samples', type=int, required=True,
-                        help='Number of Samples')
-    return parser
+# No additional CLI options
+cli_parse = None
 
 
 def cli_action(args):
@@ -73,4 +61,5 @@ def cli_action(args):
 
 
 if __name__ == "__main__":
+    cli_parse = None  # No additional options
     common_args.run_cli(cli_parse, cli_action)

--- a/src/SALib/sample/morris/__init__.py
+++ b/src/SALib/sample/morris/__init__.py
@@ -342,8 +342,6 @@ def _compute_optimised_trajectories(problem, input_sample, N, k_choices,
 
 
 def cli_parse(parser):
-    parser.add_argument('-n', '--samples', type=int, required=True,
-                        help='Number of Samples')
     parser.add_argument('-l', '--levels', type=int, required=False,
                         default=4, help='Number of grid levels \
                         (Morris only)')

--- a/src/SALib/sample/saltelli.py
+++ b/src/SALib/sample/saltelli.py
@@ -108,9 +108,6 @@ def cli_parse(parser):
     ----------
     Updated argparse object
     """
-    parser.add_argument('-n', '--samples', type=int, required=True,
-                        help='Number of Samples')
-
     parser.add_argument('--max-order', type=int, required=False, default=2,
                         choices=[1, 2],
                         help='Maximum order of sensitivity indices \


### PR DESCRIPTION
Previous PR (#222) sought to simplify usage via the terminal/console but left clean up to a later date.

I have now gone through and removed duplicated and irrelevant options for the available sampling methods.

