### PR TITLE
Bump pyscaffold version

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,11 +5,11 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = _build
+BUILDDIR      = ../build/sphinx/
 AUTODOCDIR    = api
 AUTODOCBUILD  = sphinx-apidoc
 PROJECT       = SALib
-MODULEDIR     = ../src/SALib
+MODULEDIR     = ../src/salib
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $?), 1)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,13 +50,13 @@ except FileNotFoundError:
 
 try:
     import sphinx
-    from distutils.version import LooseVersion
+    from pkg_resources import parse_version
 
     cmd_line_template = "sphinx-apidoc -f -o {outputdir} {moduledir}"
     cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
 
     args = cmd_line.split(" ")
-    if LooseVersion(sphinx.__version__) >= LooseVersion('1.7'):
+    if parse_version(sphinx.__version__) >= parse_version('1.7'):
         args = args[1:]
 
     apidoc.main(args)
@@ -72,7 +72,7 @@ except Exception as e:
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo',
               'sphinx.ext.autosummary', 'sphinx.ext.viewcode', 'sphinx.ext.coverage',
-              'sphinx.ext.doctest', 'sphinx.ext.ifconfig', 'sphinx.ext.imgmath',
+              'sphinx.ext.doctest', 'sphinx.ext.ifconfig', 'sphinx.ext.mathjax',
               'sphinx.ext.napoleon']
 
 # Add any paths that contain templates here, relative to this directory.
@@ -89,7 +89,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'SALib'
-copyright = u'2017-2019, Jon Herman, Will Usher and others'
+copyright = u'2019, Jon Herman, Will Usher and others'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -147,7 +147,10 @@ html_theme = 'alabaster'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    'sidebar_width': '300px',
+    'page_width': '1200px'
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -220,7 +223,7 @@ html_static_path = ['_static']
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'SALib-doc'
+htmlhelp_basename = 'salib-doc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -240,7 +243,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'user_guide.tex', u'SALib Documentation',
-   u'2017, Jon Herman, Will Usher and others', 'manual'),
+   u'Jon Herman, Will Usher and others', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -4,4 +4,4 @@
 License
 =======
 
-.. literalinclude:: ../LICENSE.txt
+.. include:: ../LICENSE.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ author-email = jdherman8@gmail.com
 license = mit
 url = http://salib.github.io/SALib/
 long-description = file: README.rst
-classifier =
+classifiers =
     Development Status :: 5 - Production/Stable
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.4
@@ -31,6 +31,8 @@ packages = find:
 include_package_data = True
 package_dir =
     =src
+# DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
+setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon-separated), e.g.
 # install_requires = numpy; scipy
 install_requires = numpy; scipy; matplotlib; pandas
@@ -47,6 +49,19 @@ exclude =
 # `pip install SALib[PDF]` like:
 gurobipy = gurobipy
 
+[options.entry_points]
+console_scripts = 
+  salib = SALib.scripts.salib:main
+# Add here console scripts such as:
+# console_scripts =
+#     script_name = ${package}.module:function
+# For example:
+# console_scripts =
+#     fibonacci = ${package}.skeleton:run
+# And any other entry points, for example:
+# pyscaffold.cli =
+#     awesome = pyscaffoldext.awesome.extension:AwesomeExtension
+    
 [test]
 # py.test options when running `python setup.py test`
 addopts = tests
@@ -92,7 +107,7 @@ exclude =
 [pyscaffold]
 # PyScaffold's parameters when the project was created.
 # This will be used when updating. Do not change!
-version = 3.0.2
+version = 3.2.2
 package = SALib
 extensions =
     no_skeleton

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ salib=SALib.scripts.salib:main
 def setup_package():
     needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
     sphinx = ['sphinx'] if needs_sphinx else []
-    setup(setup_requires=['pyscaffold>=3.3,<4'] + sphinx,
+    setup(setup_requires=['pyscaffold>=3.2,<4'] + sphinx,
           entry_points=entry_points,
           scripts=scripts,
           use_pyscaffold=True)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ salib=SALib.scripts.salib:main
 def setup_package():
     needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
     sphinx = ['sphinx'] if needs_sphinx else []
-    setup(setup_requires=['pyscaffold>=3.0a0,<3.1a0'] + sphinx,
+    setup(setup_requires=['pyscaffold>=3.3,<4'] + sphinx,
           entry_points=entry_points,
           scripts=scripts,
           use_pyscaffold=True)

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,28 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-    Setup file for SALib.
+    Setup file for salib.
+    Use setup.cfg to configure your project.
 
-    This file was generated with PyScaffold 3.0.2.
+    This file was generated with PyScaffold 3.2.2.
     PyScaffold helps you to put up the scaffold of your new Python project.
-    Learn more under: http://pyscaffold.org/
+    Learn more under: https://pyscaffold.org/
 """
-
 import os
 import sys
+
+from pkg_resources import VersionConflict, require
 from setuptools import setup
 
 scripts = ['src/SALib/scripts/salib.py']
 if os.name == 'nt':
     scripts.append('src/SALib/scripts/salib.bat')
 
-# Add here console scripts and other entry points in ini-style format
-entry_points = """
-# Add here console scripts such as:
-[console_scripts]
-salib=SALib.scripts.salib:main
-"""
-
-
-def setup_package():
-    needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
-    sphinx = ['sphinx'] if needs_sphinx else []
-    setup(setup_requires=['pyscaffold>=3.2,<4'] + sphinx,
-          entry_points=entry_points,
-          scripts=scripts,
-          use_pyscaffold=True)
+try:
+    require('setuptools>=38.3')
+except VersionConflict:
+    print("Error: version of setuptools is too old (<38.3)!")
+    sys.exit(1)
 
 
 if __name__ == "__main__":
-    setup_package()
+    setup(use_pyscaffold=True, scripts=scripts)

--- a/src/SALib/__init__.py
+++ b/src/SALib/__init__.py
@@ -1,6 +1,11 @@
-import pkg_resources
+# -*- coding: utf-8 -*-
+from pkg_resources import get_distribution, DistributionNotFound
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except:
+    # Change here if project is renamed and does not equal the package name
+    dist_name = 'SALib'
+    __version__ = get_distribution(dist_name).version
+except DistributionNotFound:
     __version__ = 'unknown'
+finally:
+    del get_distribution, DistributionNotFound


### PR DESCRIPTION
The current pyscaffold contains a vendored version of `setuptools_scm` that contains a bug in `list_files_in_archive` when the `setuptools` 41.2.0 `walk_revctrl()` function is called with default args. This breaks pip installation of random other packages in your requirements.txt with the following output because setuptools_scm registers itself as a plugin to setuptools:

```
writing pip-egg-info/python_bioformats.egg-info/PKG-INFO
writing requirements to pip-egg-info/python_bioformats.egg-info/requires.txt
writing top-level names to pip-egg-info/python_bioformats.egg-info/top_level.txt
writing dependency_links to pip-egg-info/python_bioformats.egg-info/dependency_links.txt
*** FileNotFoundError: [Errno 2] No such file or directory: ''
```