### PR TITLE
Update travis and package config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - pip install -r test-requirements.txt
 script:
 - python setup.py develop
-- python setup.py test
+- pytest
 after_success:
 - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ sudo: false
 language: python
 env:
   matrix:
-  - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
-  - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
+  - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="false"
+  - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true"
   - DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
   - DISTRIB="conda" PYTHON_VERSION="3.8" COVERAGE="false"
 matrix:
   allow_failures:
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="false"
     - env: DISTRIB="conda" PYTHON_VERSION="3.8" COVERAGE="false"
 addons:
   apt:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ First, create a new issue on Github with the label `bug`. Use this to describe t
 
 Then, please create a new branch with the name `bug_xxx` where xxx is the number of the issue.
 
-If possible, write a test which reproduces the bug. The tests are stored in the `SALib/tests/` folder, and are run using `pytest`.  You can run the tests with the command `python setup.py test` from the root folder of the library.
+If possible, write a test which reproduces the bug. The tests are stored in the `SALib/tests/` folder, and are run using `pytest` from the root folder of the library.  You can run the tests with the command `python setup.py test`.
 
 Then, fix the bug in the code so that the test passes.
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -50,7 +50,7 @@ To test your installation of SALib, run the following command
 
 ::
 
-    python setup.py test
+    pytest
 
 Alternatively, if you’d like also like a taste of what SALib provides,
 start a new interactive Python session
@@ -82,7 +82,7 @@ and copy/paste the code below.
     Si = sobol.analyze(problem, Y, print_to_console=True)
 
     # Print the first-order sensitivity indices
-    print Si['S1']
+    print(Si['S1'])
 
 If installed correctly, the last line above will print three values, similar
 to :code:`[ 0.30644324  0.44776661 -0.00104936]`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,9 @@ exclude =
 # Add here additional requirements for extra features, to install with:
 # `pip install SALib[PDF]` like:
 gurobipy = gurobipy
+testing = 
+    pytest
+    pytest-cov
 
 [options.entry_points]
 console_scripts = 
@@ -64,7 +67,8 @@ console_scripts =
     
 [test]
 # py.test options when running `python setup.py test`
-addopts = tests
+# addopts = tests
+extras = True
 
 [tool:pytest]
 # Options for py.test:
@@ -77,6 +81,7 @@ norecursedirs =
     dist
     build
     .tox
+testpaths = tests
 
 [aliases]
 release = sdist bdist_wheel upload


### PR DESCRIPTION
Allow failure on Py3.5 - build is failing due to the use of features only found in Py3.6

Use of `python setup.py test` raises deprecation warning. Switched to `pytest` to resolve.

Updated documentation to match