### PR TITLE
Identical default num_resamples for delta, dgsm and morris #291

### DIFF
--- a/src/SALib/analyze/delta.py
+++ b/src/SALib/analyze/delta.py
@@ -9,7 +9,7 @@ from . import common_args
 from ..util import read_param_file, ResultDict
 
 
-def analyze(problem, X, Y, num_resamples=10,
+def analyze(problem, X, Y, num_resamples=100,
             conf_level=0.95, print_to_console=False, seed=None):
     """Perform Delta Moment-Independent Analysis on model outputs.
 

--- a/src/SALib/analyze/dgsm.py
+++ b/src/SALib/analyze/dgsm.py
@@ -9,7 +9,7 @@ from . import common_args
 from ..util import read_param_file, ResultDict
 
 
-def analyze(problem, X, Y, num_resamples=1000,
+def analyze(problem, X, Y, num_resamples=100,
             conf_level=0.95, print_to_console=False, seed=None):
     """Calculates Derivative-based Global Sensitivity Measure on model outputs.
 

--- a/src/SALib/analyze/morris.py
+++ b/src/SALib/analyze/morris.py
@@ -11,7 +11,7 @@ from ..sample.morris import compute_delta
 
 
 def analyze(problem, X, Y,
-            num_resamples=1000,
+            num_resamples=100,
             conf_level=0.95,
             print_to_console=False,
             num_levels=4,


### PR DESCRIPTION
Change default num_resamples values for Delta, DGSM and Morris to identical default num_resamples of 100 samples, which Closes #291 