### PR TITLE
PAWN method

### DIFF
--- a/examples/pawn/pawn.bat
+++ b/examples/pawn/pawn.bat
@@ -1,0 +1,65 @@
+@echo off
+
+REM Example: generating samples from the command line
+salib sample latin ^
+	-n 1000 ^
+	-p ../../src/SALib/test_functions/params/Ishigami.txt ^
+	-o ../data/model_input.txt ^
+	--delimiter=" " ^
+	--precision=8 ^
+	--seed=100
+
+REM You can also use the module directly through Python
+REM python -m SALib.sample.latin ^
+REM 	   -n 1000 ^
+REM 	   -p ./src/SALib/test_functions/params/Ishigami.txt ^
+REM 	   -o model_input.txt ^
+REM 	   --delimiter=" " ^
+REM 	   --precision=8 ^
+REM 		 --seed=100
+
+
+
+REM Options:
+REM -p, --paramfile: Your parameter range file (3 columns: parameter name, lower bound, upper bound)
+REM
+REM -n, --samples: Sample size.
+REM				 Number of model runs is N
+REM
+REM -o, --output: File to output your samples into.
+REM
+REM --delimiter (optional): Output file delimiter.
+REM
+REM --precision (optional): Digits of precision in the output file. Default is 8.
+REM
+REM -M: RBD-FAST M coefficient, default 4
+REM
+REM -s, --seed (optional): Seed value for random number generation
+
+REM Run the model using the inputs sampled above, and save outputs
+python -c "from SALib.test_functions import Ishigami; import numpy as np; np.savetxt('../data/model_output.txt', Ishigami.evaluate(np.loadtxt('../data/model_input.txt')))"
+
+REM Then use the output to run the analysis.
+REM Sensitivity indices will print to command line. Use ">" to write to file.
+
+salib analyze pawn ^
+	-p ../../src/SALib/test_functions/params/Ishigami.txt ^
+	-X ../data/model_input.txt ^
+	-Y ../data/model_output.txt ^
+	--seed=100
+
+REM python -m SALib.analyze.rbd_fast ^
+REM 	-p ../../src/SALib/test_functions/params/Ishigami.txt ^
+REM 	-X ../data/model_input.txt ^
+REM 	-Y ../data/model_output.txt ^
+REM 	--seed=100
+
+REM Options:
+REM -p, --paramfile: Your parameter range file (3 columns: parameter name, lower bound, upper bound)
+REM
+REM -X, --model-input-file: File of model input values to analyze
+REM -Y, --model-output-file: File of model output values to analyze
+REM
+REM --delimiter (optional): Model output file delimiter.
+REM
+REM -s, --seed (optional): Seed value for random number generation

--- a/examples/pawn/pawn.py
+++ b/examples/pawn/pawn.py
@@ -1,0 +1,24 @@
+import sys
+sys.path.append('../..')
+
+from SALib.analyze import pawn
+from SALib.sample import latin
+from SALib.test_functions import Ishigami
+from SALib.util import read_param_file
+
+# Read the parameter range file and generate samples
+problem = read_param_file('../../src/SALib/test_functions/params/Ishigami.txt')
+
+# Generate samples
+param_values = latin.sample(problem, 1000)
+
+# Run the "model" and save the output in a text file
+# This will happen offline for external models
+Y = Ishigami.evaluate(param_values)
+
+# Perform the sensitivity analysis using the model output
+# Specify which column of the output file to analyze (zero-indexed)
+Si = pawn.analyze(problem, param_values, Y, S=10, print_to_console=True)
+# Returns a dictionary with key 'PAWN'
+# e.g. Si['PAWN'] contains the total-order index for each parameter, in the
+# same order as the parameter file

--- a/examples/pawn/pawn.py
+++ b/examples/pawn/pawn.py
@@ -6,19 +6,34 @@ from SALib.sample import latin
 from SALib.test_functions import Ishigami
 from SALib.util import read_param_file
 
+import numpy as np
+
 # Read the parameter range file and generate samples
 problem = read_param_file('../../src/SALib/test_functions/params/Ishigami.txt')
 
 # Generate samples
-param_values = latin.sample(problem, 1000)
+X = latin.sample(problem, 500)
 
 # Run the "model" and save the output in a text file
 # This will happen offline for external models
-Y = Ishigami.evaluate(param_values)
+Y = Ishigami.evaluate(X, A=2.0, B=1.0)
 
 # Perform the sensitivity analysis using the model output
 # Specify which column of the output file to analyze (zero-indexed)
-Si = pawn.analyze(problem, param_values, Y, S=10, print_to_console=True)
-# Returns a dictionary with key 'PAWN'
-# e.g. Si['PAWN'] contains the total-order index for each parameter, in the
+Si = pawn.analyze(problem, X, Y, S=10, stat='median', 
+                  num_resamples=100, print_to_console=True)
+# Returns a dictionary with key 'PAWNi' and 'PAWNi_conf'
+# e.g. Si['PAWNi'] contains the PAWN index for each parameter, in the
 # same order as the parameter file
+
+# To display plots:
+# import matplotlib.pyplot as plt
+# Si.plot()
+# plt.show()
+
+# Expected sensitivities, according to Pianosi and Wagener (2018)
+# with 500 samples
+# https://doi.org/10.1016/j.envsoft.2018.07.019
+# x1: 0.50
+# x2: 0.16
+# x3: 0.29

--- a/examples/pawn/pawn.sh
+++ b/examples/pawn/pawn.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Example: generating samples from the command line
+salib sample latin \
+	-n 1000 \
+	-p ../../src/SALib/test_functions/params/Ishigami.txt \
+	-o ../data/model_input.txt \
+	--delimiter=' ' \
+	--precision=8 \
+	--seed=100
+
+# You can also use the module directly through Python
+# python -m SALib.sample.latin \
+# 	   -n 1000 \
+# 	   -p ./src/SALib/test_functions/params/Ishigami.txt \
+# 	   -o model_input.txt \
+# 	   --delimiter=' ' \
+# 	   --precision=8 \
+# 		 --seed=100
+
+# Run the model using the inputs sampled above, and save outputs
+python -c "from SALib.test_functions import Ishigami; import numpy as np; np.savetxt('../data/model_output.txt', Ishigami.evaluate(np.loadtxt('../data/model_input.txt')))"
+
+# Then use the output to run the analysis.
+# Sensitivity indices will print to command line. Use ">" to write to file.
+
+salib analyze pawn \
+	-p ../../src/SALib/test_functions/params/Ishigami.txt \
+	-X ../data/model_input.txt \
+	-Y ../data/model_output.txt \
+	--seed=100
+
+# Options:
+# -p, --paramfile: Your parameter range file (3 columns: parameter name, lower bound, upper bound)
+#
+# -Y, --model-output-file: File of model output values to analyze
+# -X, --model-input-file: File of model input values to analyze
+# -S, --slices: Number of slices to take
+#
+# --delimiter (optional): Model output file delimiter.
+#
+# -s, --seed (optional): Seed value for random number generation

--- a/src/SALib/analyze/pawn.py
+++ b/src/SALib/analyze/pawn.py
@@ -193,12 +193,14 @@ def _calc_ks(X_r, X_q, Y_sel, S, stat_func):
 def cli_parse(parser):
     parser.add_argument('-X', '--model-input-file',
                         type=str, required=True, help='Model input file')
-
     parser.add_argument('-S', '--slices',
                         type=int, required=False, default=10, help='Number of intervals to partition input-output space')
-    
-    parser.add_argument('-s', '--statistic',
+    parser.add_argument('-st', '--statistic',
                         type=str, required=False, default='median', help='Numpy compatible statistic to use (defaults to median)')
+    parser.add_argument('-r', '--resamples', type=int, required=False,
+                        default=100,
+                        help='Number of bootstrap resamples for Sobol '
+                        'confidence intervals')
     return parser
 
 

--- a/src/SALib/analyze/pawn.py
+++ b/src/SALib/analyze/pawn.py
@@ -158,7 +158,6 @@ def _bootstrap(X_di, seq, Y, Nc, S, num_resamples, conf_level, stat_func):
            https://doi.org/10.1016/j.envsoft.2017.02.001
 
     """
-
     s = np.full(num_resamples, np.nan)
     Y_len = Y.shape[0]
     for i in range(num_resamples):
@@ -168,8 +167,7 @@ def _bootstrap(X_di, seq, Y, Nc, S, num_resamples, conf_level, stat_func):
         X_r = X_di[r]
         X_q = np.nanquantile(X_r, seq)
 
-        b_s, _ = _calc_ks(X_r, X_q, Y_sel, S, stat_func)
-        s[i] = stat_func(b_s)
+        s[i], _ = _calc_ks(X_r, X_q, Y_sel, S, stat_func)
     
     return norm.ppf(0.5 + conf_level / 2.0) * s.std(ddof=1)
 

--- a/src/SALib/analyze/pawn.py
+++ b/src/SALib/analyze/pawn.py
@@ -1,0 +1,109 @@
+import numpy as np
+from scipy.stats import ks_2samp
+
+from . import common_args
+
+from ..util import (read_param_file, ResultDict, 
+                    extract_group_names, _check_groups)
+
+
+def analyze(problem, X, Y, S=10, print_to_console=False, seed=None):
+    """Performs PAWN sensitivity analysis.
+
+    Ported from an implementation in `R` by Baroni & Francke (2020)
+    https://github.com/baronig/GSA-cvd
+
+
+    Parameters
+    ----------
+    problem : dict
+        The problem definition
+    X : numpy.array
+        A NumPy array containing the model inputs
+    Y : numpy.array
+        A NumPy array containing the model outputs
+    S : int
+        Number of slides (default 10)
+    print_to_console : bool
+        Print results directly to console (default False)
+    seed : int
+        Seed value to ensure deterministic results
+
+    References
+    ----------
+    .. [1] Pianosi, F., Wagener, T., 2015. 
+           A simple and efficient method for global sensitivity analysis 
+           based on cumulative distribution functions. 
+           Environmental Modelling & Software 67, 1–11. 
+           https://doi.org/10.1016/j.envsoft.2015.01.004
+
+
+    Examples
+    --------
+    >>> X = latin.sample(problem, 1000)
+    >>> Y = Ishigami.evaluate(X)
+    >>> Si = pawn.analyze(problem, X, Y, S=10, print_to_console=False)
+    """
+    if seed:
+        np.random.seed(seed)
+
+    groups = _check_groups(problem)
+    print("Groups: ", groups)
+    if not groups:
+        D = problem['num_vars']
+    else:
+        _, D = extract_group_names(problem.get('groups'))
+
+    result = np.full((D, ), np.nan)
+    temp_pawn = np.full((S, D), np.nan)
+
+    step = (1/S)
+    for d_i in range(D):
+        seq = np.arange(0, 1+step, step)
+        X_q = np.nanquantile(X[:, d_i], seq)
+
+        for s in range(S):
+            Y_sel = Y[(X[:, d_i] >= X_q[s]) & (X[:, d_i] < X_q[s+1])]
+
+            # KD value
+            # Function returns a KS object which holds the KS statistic
+            # and p-value
+            # Note from documentation:
+            # if the K-S statistic is small or the p-value is high, then 
+            # we cannot reject the hypothesis that the distributions of 
+            # the two samples are the same.
+            ks = ks_2samp(Y_sel, Y)
+            temp_pawn[s, d_i] = ks.statistic 
+
+        result[d_i] = np.median(temp_pawn[:, d_i])
+
+    Si = ResultDict([('PAWN', result)])
+    Si['names'] = problem['names']
+
+    if print_to_console:
+        print(Si.to_df())
+
+    return Si
+
+
+def cli_parse(parser):
+    parser.add_argument('-X', '--model-input-file',
+                        type=str, required=True, help='Model input file')
+
+    parser.add_argument('-S', '--slices',
+                        type=int, required=False, help='Number of slices to take')
+    return parser
+
+
+def cli_action(args):
+    problem = read_param_file(args.paramfile)
+    X = np.loadtxt(args.model_input_file,
+                   delimiter=args.delimiter)
+    Y = np.loadtxt(args.model_output_file,
+                   delimiter=args.delimiter,
+                   usecols=(args.column,))
+    analyze(problem, X, Y, S=args.slices, print_to_console=True, seed=args.seed)
+
+
+if __name__ == "__main__":
+    common_args.run_cli(cli_parse, cli_action)

--- a/src/SALib/analyze/pawn.py
+++ b/src/SALib/analyze/pawn.py
@@ -135,16 +135,14 @@ def _bootstrap(X_di, seq, Y, Nc, S, num_resamples, conf_level, stat_func):
 
     Parameters
     ----------
-    Y : Output
-    Nc : int,
+    Y : np.array
+        Model outputs
+    Nc : int
         Size of conditional sample
     num_resamples : int
         Number of bootstrap samples to take (< N, where N is number of available samples)
     conf_level : float
         The confidence interval level (default 0.95)
-
-    we will derive the unconditional sample YU by randomly extracting from `Y` a subsample of size
-    `N_{c}`, where `N_{c} < N`
 
 
     References

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,8 +31,3 @@ def test_cli_avail_methods():
             # Just try to access the functions - raises error on failure
             approach.cli_parse
             approach.cli_action
-
-
-if __name__ == '__main__':
-    test_cli_usage()
-    test_cli_avail_methods()

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -215,11 +215,22 @@ def test_sobol():
             expected_output, result)
 
 
-if __name__ == '__main__':
-    test_delta()
-    test_dgsm()
-    test_fast()
-    test_ff()
-    test_morris()
-    test_rbd_fast()
-    test_sobol()
+def test_pawn():
+    # Generate inputs
+    cmd = f"python {salib_cli} sample latin -p {ishigami_fp} -o {input_path} \
+    --precision=8 -n 1000 --seed=100".split()
+
+    result = subprocess.check_output(cmd, universal_newlines=True)
+    np.savetxt(output_path, Ishigami.evaluate(
+        np.loadtxt(input_path)))
+
+    analyze_cmd = f"python {salib_cli} analyze pawn -p {ishigami_fp}\
+        -X {input_path} -Y {output_path} -r 100 --seed=100".split()
+
+    result = subprocess.check_output(analyze_cmd, universal_newlines=True)
+    result = re.sub(r'[\n\t\s]*', '', result)
+
+    expected_output = 'PAWNiPAWNi_confx10.25200.073777x20.39150.075457x30.11500.058947'
+    assert len(result) > 0 and result == expected_output, \
+        "Results did not match expected values:\n\n Expected: \n{} \n\n Got: \n{}".format(
+            expected_output, result)

--- a/tests/test_pawn.py
+++ b/tests/test_pawn.py
@@ -1,0 +1,45 @@
+import sys
+sys.path.append('../..')
+
+from SALib.sample import latin
+from SALib.analyze import pawn
+from SALib.test_functions import Ishigami
+
+import numpy as np
+
+
+def test_pawn_analyze():
+    """Confirms PAWN indices are in line with reported expected values.
+
+    Expected values are taken from [1] for the Ishigami test function.
+
+
+    References
+    ----------
+    .. [1] Pianosi, F., Wagener, T., 2018. 
+           Distribution-based sensitivity analysis from a generic input-output 
+           sample. 
+           Environmental Modelling & Software 108, 197–207. 
+           https://doi.org/10.1016/j.envsoft.2018.07.019
+    """
+
+    problem = {
+               'num_vars': 3,
+               'names': ['x1', 'x2', 'x3'],
+               'bounds': [[-np.pi, np.pi]*3]
+    }
+    X = latin.sample(problem, 500)
+    Y = Ishigami.evaluate(X, A=2.0, B=1.0)
+    Si = pawn.analyze(problem, X, Y, S=10, stat='median', 
+                      num_resamples=100)
+
+    Si_df = Si.to_df()
+
+    bnd = Si_df['PAWNi_conf'].values.T
+    p_i = Si_df['PAWNi']
+
+    expected_vals = np.array([0.5, 0.16, 0.29])
+
+    in_bounds = ((p_i >= (expected_vals - bnd)) & (p_i <= (expected_vals + bnd)))
+
+    assert np.all(in_bounds)


### PR DESCRIPTION
Tests rely on PAWN indices to be in line with reported expected values for the Ishigami test function
(in https://doi.org/10.1016/j.envsoft.2018.07.019)


Resolves #123 