### PR TITLE
Docstring fixes for (e)FAST method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Python 3 (from SALib v1.2 onwards SALib does not officially support Python 2)
   `Campolongo et al. 2007 <http://www.sciencedirect.com/science/article/pii/S1364815206002805>`__,
   `Ruano et al. 2012 <https://doi.org/10.1016/j.envsoft.2012.03.008>`__)
 
-* Fourier Amplitude Sensitivity Test (FAST) (`Cukier et al. 1973 <http://scitation.aip.org/content/aip/journal/jcp/59/8/10.1063/1.1680571>`__,
+* extended Fourier Amplitude Sensitivity Test (FAST) (`Cukier et al. 1973 <http://scitation.aip.org/content/aip/journal/jcp/59/8/10.1063/1.1680571>`__,
   `Saltelli et al. 1999 <http://amstat.tandfonline.com/doi/abs/10.1080/00401706.1999.10485594>`__)
 
 * Random Balance Designs - Fourier Amplitude Sensitivity Test (RBD-FAST) (`Tarantola et al. 2006 <https://hal.archives-ouvertes.fr/hal-01065897/file/Tarantola06RESS_HAL.pdf>`__,

--- a/examples/Problem/problem_spec.py
+++ b/examples/Problem/problem_spec.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     sp = ProblemSpec({
         'names': ['x1', 'x2', 'x3'],
         'groups': None,
-        'bounds': [[-np.pi, np.pi]*3],
+        'bounds': [[-np.pi, np.pi]]*3,
         'outputs': ['Y']
     })
 

--- a/examples/rbd_fast/rbd_fast.py
+++ b/examples/rbd_fast/rbd_fast.py
@@ -19,6 +19,6 @@ Y = Ishigami.evaluate(param_values)
 # Perform the sensitivity analysis using the model output
 # Specify which column of the output file to analyze (zero-indexed)
 Si = rbd_fast.analyze(problem, param_values, Y, print_to_console=True)
-# Returns a dictionary with keys 'S1' and 'ST'
+# Returns a dictionary with key 'S1'
 # e.g. Si['S1'] contains the first-order index for each parameter, in the
 # same order as the parameter file

--- a/src/SALib/analyze/fast.py
+++ b/src/SALib/analyze/fast.py
@@ -9,7 +9,7 @@ from ..util import read_param_file, ResultDict
 
 
 def analyze(problem, Y, M=4, num_resamples=100, conf_level=0.95, print_to_console=False, seed=None):
-    """Performs the Fourier Amplitude Sensitivity Test (FAST) on model outputs.
+    """Performs the extended Fourier Amplitude Sensitivity Test (eFAST) on model outputs.
 
     Returns a dictionary with keys 'S1' and 'ST', where each entry is a list of
     size D (the number of parameters) containing the indices in the same order

--- a/src/SALib/sample/fast_sampler.py
+++ b/src/SALib/sample/fast_sampler.py
@@ -7,9 +7,9 @@ from .. util import scale_samples, read_param_file
 
 
 def sample(problem, N, M=4, seed=None):
-    """Generate model inputs for the Fourier Amplitude Sensitivity Test (FAST).
+    """Generate model inputs for the extended Fourier Amplitude Sensitivity Test (eFAST).
 
-    Returns a NumPy matrix containing the model inputs required by the Fourier
+    Returns a NumPy matrix containing the model inputs required by the extended Fourier
     Amplitude sensitivity test.  The resulting matrix contains N * D rows and D
     columns, where D is the number of parameters.  The samples generated are
     intended to be used by :func:`SALib.analyze.fast.analyze`.
@@ -78,6 +78,7 @@ def sample(problem, N, M=4, seed=None):
             X[l, j] = g
 
     X = scale_samples(X, problem)
+
     return X
 
 


### PR DESCRIPTION
Clarify in docstring which FAST method is implemented, which caused some confusion (https://github.com/SALib/SALib/issues/404)


Closes #404 