### PR TITLE
Parallel analysis

### DIFF
--- a/examples/Problem/multi_output.py
+++ b/examples/Problem/multi_output.py
@@ -18,7 +18,7 @@ sp = ProblemSpec({
     'outputs': ['max_P', 'Utility', 'Inertia', 'Reliability']
 })
 
-(sp.sample_saltelli(1000)
+(sp.sample_saltelli(1024)
     .evaluate(lake_problem.evaluate)
     .analyze_sobol())
 

--- a/examples/Problem/problem_spec.py
+++ b/examples/Problem/problem_spec.py
@@ -38,16 +38,25 @@ if __name__ == '__main__':
         .analyze_sobol(calc_second_order=True, conf_level=0.95))
     print("Time taken with 1 core:", time.perf_counter() - start, '\n')
 
+    # Same above example, but passing in specific functions
+    # (sp.sample(saltelli.sample, 25000, calc_second_order=True)
+    #     .evaluate(Ishigami.evaluate)
+    #     .analyze(sobol.analyze, calc_second_order=True, conf_level=0.95))
+
     # Samples, model results and analyses can be extracted:
     # print(sp.samples)
     # print(sp.results)
     # print(sp.analysis)
     # print(sp.to_df())
 
-    # Same above, but passing in specific functions
-    # (sp.sample(saltelli.sample, 25000, calc_second_order=True)
-    #     .evaluate(Ishigami.evaluate)
-    #     .analyze(sobol.analyze, calc_second_order=True, conf_level=0.95))
+    # Can set pre-existing samples/results as needed
+    # sp.samples = some_numpy_array
+    # sp.set_samples(some_numpy_array)
+    #
+    # Using method chaining...
+    # (sp.set_samples(some_numpy_array)
+    #    .set_results(some_result_array)
+    #    .analyze_sobol(calc_second_order=True, conf_level=0.95))
 
     # Parallel example
     start = time.perf_counter()

--- a/examples/Problem/problem_spec.py
+++ b/examples/Problem/problem_spec.py
@@ -53,8 +53,10 @@ if __name__ == '__main__':
     start = time.perf_counter()
     (sp.sample(saltelli.sample, 2**15)
          # can specify number of processors to use with `nprocs`
+         # this will be capped to the number of detected processors
+         # or, in the case of analysis, the number of outputs.
         .evaluate_parallel(Ishigami.evaluate, nprocs=2)
-        .analyze(sobol.analyze, calc_second_order=True, conf_level=0.95))
+        .analyze_sobol(calc_second_order=True, conf_level=0.95, nprocs=2))
     print("Time taken with 2 cores:", time.perf_counter() - start, '\n')
 
     print(sp)
@@ -66,7 +68,7 @@ if __name__ == '__main__':
                'localhost:55776')
 
     start = time.perf_counter()
-    (sp.sample(saltelli.sample, 25000)
+    (sp.sample(saltelli.sample, 2**15)
         .evaluate_distributed(Ishigami.evaluate, nprocs=2, servers=servers, verbose=True)
         .analyze(sobol.analyze, calc_second_order=True, conf_level=0.95))
     print("Time taken with distributed cores:", time.perf_counter() - start, '\n')

--- a/examples/Problem/problem_spec.py
+++ b/examples/Problem/problem_spec.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
 
     # Single core example
     start = time.perf_counter()
-    (sp.sample_saltelli(25000)
+    (sp.sample_saltelli(2**15)
         .evaluate(Ishigami.evaluate)
         .analyze_sobol(calc_second_order=True, conf_level=0.95))
     print("Time taken with 1 core:", time.perf_counter() - start, '\n')
@@ -51,11 +51,11 @@ if __name__ == '__main__':
 
     # Parallel example
     start = time.perf_counter()
-    (sp.sample(saltelli.sample, 25000)
+    (sp.sample(saltelli.sample, 2**15)
          # can specify number of processors to use with `nprocs`
         .evaluate_parallel(Ishigami.evaluate, nprocs=2)
         .analyze(sobol.analyze, calc_second_order=True, conf_level=0.95))
-    print("Time taken with all available cores:", time.perf_counter() - start, '\n')
+    print("Time taken with 2 cores:", time.perf_counter() - start, '\n')
 
     print(sp)
     

--- a/examples/Problem/problem_spec.py
+++ b/examples/Problem/problem_spec.py
@@ -1,15 +1,15 @@
 """Example showing how to use the ProblemSpec approach.
 
-Showcases method chaining, and parallel model runs using
-all available processors.
+Showcases method chaining, and parallel model runs using 2 processors.
 
 The following caveats apply:
 
-1. Functions passed into `sample`, `analyze`, `evaluate` and `evaluate_*` must 
+1. Functions passed into `sample`, `analyze` and `evaluate` must 
    accept a numpy array of `X` values as the first parameter, and return a 
    numpy array of results.
-2. Parallel evaluation is only beneficial for long-running models
-3. Currently, model results must fit in memory - no on-disk caching is provided.
+2. Parallel evaluation/analysis is only beneficial for long-running models 
+   or large datasets
+3. Currently, results must fit in memory - no on-disk caching is provided.
 """
 
 from SALib.analyze import sobol
@@ -64,7 +64,7 @@ if __name__ == '__main__':
          # can specify number of processors to use with `nprocs`
          # this will be capped to the number of detected processors
          # or, in the case of analysis, the number of outputs.
-        .evaluate_parallel(Ishigami.evaluate, nprocs=2)
+        .evaluate(Ishigami.evaluate, nprocs=2)
         .analyze_sobol(calc_second_order=True, conf_level=0.95, nprocs=2))
     print("Time taken with 2 cores:", time.perf_counter() - start, '\n')
 

--- a/src/SALib/analyze/sobol.py
+++ b/src/SALib/analyze/sobol.py
@@ -65,7 +65,9 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
 
     """
     if seed:
-        np.random.seed(seed)
+        # Set seed to ensure CIs are the same
+        rng = np.random.default_rng(seed).integers
+
     # determining if groups are defined and adjusting the number
     # of rows in the cross-sampled matrix accordingly
     groups = _check_groups(problem)
@@ -90,7 +92,7 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
     Y = (Y - Y.mean()) / Y.std()
 
     A, B, AB, BA = separate_output_values(Y, D, N, calc_second_order)
-    r = np.random.randint(N, size=(N, num_resamples))
+    r = rng(N, size=(N, num_resamples))
     Z = norm.ppf(0.5 + conf_level / 2)
 
     if not parallel:

--- a/src/SALib/analyze/sobol.py
+++ b/src/SALib/analyze/sobol.py
@@ -67,6 +67,8 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
     if seed:
         # Set seed to ensure CIs are the same
         rng = np.random.default_rng(seed).integers
+    else:
+        rng = np.random.randint
 
     # determining if groups are defined and adjusting the number
     # of rows in the cross-sampled matrix accordingly

--- a/src/SALib/test_functions/lake_problem.py
+++ b/src/SALib/test_functions/lake_problem.py
@@ -55,7 +55,7 @@ def lake_problem(X: FLOAT_OR_ARRAY, a: FLOAT_OR_ARRAY = 0.1, q: FLOAT_OR_ARRAY =
     return X_t1
 
 
-def evaluate_lake(values: np.ndarray) -> np.ndarray:
+def evaluate_lake(values: np.ndarray, seed=101) -> np.ndarray:
     """Evaluate the Lake Problem with an array of parameter values.
 
     .. [1] Hadka, D., Herman, J., Reed, P., Keller, K., (2015).
@@ -86,15 +86,17 @@ def evaluate_lake(values: np.ndarray) -> np.ndarray:
     -------
     np.ndarray, of Phosphorus pollution over time `t`
     """
+    rng = np.random.default_rng(seed)
+
     nvars = values.shape[0]
 
     a, q, b, mean, stdev = values.T
 
     sq_mean = mean**2
     sq_std = stdev**2
-    eps = np.random.lognormal(log(sq_mean / sqrt(sq_std + sq_mean)),
-                              sqrt(log(1.0 + sq_std / sq_mean)),
-                              size=nvars)
+    eps = rng.lognormal(log(sq_mean / sqrt(sq_std + sq_mean)),
+                        sqrt(log(1.0 + sq_std / sq_mean)),
+                        size=nvars)
 
     Y = np.zeros((nvars, nvars))
     for t in range(nvars):
@@ -104,7 +106,7 @@ def evaluate_lake(values: np.ndarray) -> np.ndarray:
     return Y
 
 
-def evaluate(values: np.ndarray, nvars: int = 100):
+def evaluate(values: np.ndarray, nvars: int = 100, seed=101):
     """Evaluate the Lake Problem with an array of parameter values.
 
     Parameters
@@ -126,7 +128,7 @@ def evaluate(values: np.ndarray, nvars: int = 100):
     nsamples = len(a)
     Y = np.empty((nsamples, 4))
     for i in range(nsamples):
-        tmp = evaluate_lake(values[i, :5])
+        tmp = evaluate_lake(values[i, :5], seed=seed)
 
         a_i = a[i]
         q_i = q[i]

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -512,7 +512,7 @@ class ProblemSpec(dict):
         if self._samples is not None:
             arr_shape = self._samples.shape
             if len(arr_shape) == 1:
-                arr_shape = (arr_shape, 1)
+                arr_shape = (arr_shape[0], 1)
             nr, nx = arr_shape
             print('Samples:')
             print(f'\t{nx} parameters:', self['names'])
@@ -520,7 +520,7 @@ class ProblemSpec(dict):
         if self._results is not None:
             arr_shape = self._results.shape
             if len(arr_shape) == 1:
-                arr_shape = (arr_shape, 1)
+                arr_shape = (arr_shape[0], 1)
             nr, ny = arr_shape
             print('Outputs:')
             print(f"\t{ny} outputs:", self['outputs'])

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -149,6 +149,9 @@ class ProblemSpec(dict):
         *args : list,
             Additional arguments to be passed to `func`
 
+        nprocs : int,
+            If specified, attempts to parallelize model evaluations
+
         **kwargs : dict,
             Additional keyword arguments passed to `func`
 
@@ -277,7 +280,6 @@ class ProblemSpec(dict):
     def analyze(self, func, *args, **kwargs):
         """Analyze sampled results using given function.
 
-
         Parameters
         ----------
         func : function,
@@ -287,6 +289,9 @@ class ProblemSpec(dict):
 
         *args : list,
             Additional arguments to be passed to `func`
+
+        nprocs : int,
+            If specified, attempts to parallelize model evaluations
 
         **kwargs : dict,
             Additional keyword arguments passed to `func`
@@ -382,12 +387,12 @@ class ProblemSpec(dict):
 
             if ptqdm_available:
                 # Display progress bar if available
-                res = p_imap(lambda y: func(self, Y=y), 
-                             [self._results[:, i] for i in range(Yn)], 
+                res = p_imap(lambda y: func(self, Y=y),
+                             [self._results[:, i] for i in range(Yn)],
                              num_cpus=nprocs)
             else:
                 with Pool(nprocs) as pool:
-                    res = list(pool.imap(lambda y: func(self, Y=y), 
+                    res = list(pool.imap(lambda y: func(self, Y=y),
                                [self._results[:, i] for i in range(Yn)]))
 
         # Assign by output name if more than 1 output, otherwise

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -202,6 +202,8 @@ class ProblemSpec(dict):
         if nprocs is None:
             nprocs = max_procs
         else:
+            if nprocs > max_procs:
+                warnings.warn(f"{nprocs} processors requested but only {max_procs} found.")
             nprocs = min(max_procs, nprocs)
 
         # Create wrapped partial function to allow passing of additional args
@@ -377,6 +379,8 @@ class ProblemSpec(dict):
         Yn = len(self['outputs'])
         if Yn == 1:
             # Only single output, cannot parallelize
+            warnings.warn(f"Analysis was not parallelized: {nprocs} processors requested for 1 output.")
+
             res = func(self, Y=self._results)
         else:
             max_procs = cpu_count()

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -119,17 +119,19 @@ class ProblemSpec(dict):
 
         return self
 
-    def set_samples(self, samples):
+    def set_samples(self, samples: np.ndarray):
         """Set previous samples used."""
         self.samples = samples
 
         return self
 
-    def set_results(self, results):
+    def set_results(self, results: np.ndarray):
         """Set previously available model results."""
+        if self.samples is not None:
+            assert self.samples.shape[0] == results.shape[0], \
+                "Provided result array does not match existing number of existing samples!"
+
         self.results = results
-        # if self.samples is not None:
-        #     warnings.warn('Existing samples found - make sure these results are for those samples!')
 
         return self
 

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -472,11 +472,17 @@ class ProblemSpec(dict):
 
             self.__setattr__(method_name, MethodType(self._method_creator(func, 'analyze'), self))
 
-    def __repr__(self):
+    def __str__(self):
         if self._samples is not None:
-            print('Samples:', self._samples.shape, "\n")
+            nr, nx = self._samples.shape
+            print('Samples:')
+            print(f'\t{nx} parameters:', self['names'])
+            print(f'\t{nr} evaluations', '\n')
         if self._results is not None:
-            print('Outputs:', self._results.shape, "\n")
+            nr, ny = self._results.shape
+            print('Outputs:')
+            print(f"\t{ny} outputs:", self['outputs'])
+            print(f'\t{nr} evaluations', '\n')
         if self._analysis is not None:
             print('Analysis:\n')
             an_res = self._analysis

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -291,6 +291,8 @@ class ProblemSpec(dict):
         if 'X' in func.__code__.co_varnames:
             # enforce passing of X if expected
             func = partial(func, *args, X=self._samples, **kwargs)
+        else:
+            func = partial(func, *args, **kwargs)
 
         out_cols = self.get('outputs', None)
         if out_cols is None:
@@ -303,9 +305,9 @@ class ProblemSpec(dict):
         if len(self['outputs']) > 1:
             self._analysis = {}
             for i, out in enumerate(self['outputs']):
-                self._analysis[out] = func(self, *args, Y=self._results[:, i], **kwargs)
+                self._analysis[out] = func(self, Y=self._results[:, i])
         else:
-            self._analysis = func(self, *args, Y=self._results, **kwargs)
+            self._analysis = func(self, Y=self._results)
 
         return self
 
@@ -343,6 +345,8 @@ class ProblemSpec(dict):
         if 'X' in func.__code__.co_varnames:
             # enforce passing of X if expected
             func = partial(func, *args, X=self._samples, **kwargs)
+        else:
+            func = partial(func, *args, **kwargs)
 
         out_cols = self.get('outputs', None)
         if out_cols is None:
@@ -484,7 +488,7 @@ class ProblemSpec(dict):
             print(f"\t{ny} outputs:", self['outputs'])
             print(f'\t{nr} evaluations', '\n')
         if self._analysis is not None:
-            print('Analysis:\n')
+            print('Analysis:')
             an_res = self._analysis
 
             allowed_types = (list, tuple)

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -243,7 +243,7 @@ def test_sobol():
     result = subprocess.check_output(analyze_cmd, universal_newlines=True)
     result = re.sub(r'[\n\t\s]*', '', result)
 
-    expected_output = 'STST_confx10.5579470.084460x20.4421890.044082x30.2414020.028068S1S1_confx10.3105760.060494x20.4436530.054648x3-0.0129620.054765S2S2_conf(x1,x2)-0.0143970.084384(x1,x3)0.2462310.103131(x2,x3)0.0005390.064658'
+    expected_output = "STST_confx10.5579470.085851x20.4421890.041396x30.2414020.028607S1S1_confx10.3105760.059615x20.4436530.053436x3-0.0129620.053891S2S2_conf(x1,x2)-0.0143970.083679(x1,x3)0.2462310.103117(x2,x3)0.0005390.064169"
     assert len(result) > 0 and result == expected_output, \
         "Results did not match expected values:\n\n Expected: \n{} \n\n Got: \n{}".format(
             expected_output, result)

--- a/tests/test_problem_spec.py
+++ b/tests/test_problem_spec.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 
 import numpy as np
 
@@ -83,6 +84,56 @@ def test_sp_setters():
        .analyze_sobol(calc_second_order=True, conf_level=0.95))
 
 
-if __name__ == '__main__':
-    test_sp_setters()
+def test_parallel_single_output():
+    # Create the SALib Problem specification
+    sp = ProblemSpec({
+        'names': ['x1', 'x2', 'x3'],
+        'groups': None,
+        'bounds': [[-np.pi, np.pi]]*3,
+        'outputs': ['Y']
+    })
 
+    # Single core example
+    (sp.sample_saltelli(2**8)
+        .evaluate(Ishigami.evaluate)
+        .analyze_sobol(calc_second_order=True, conf_level=0.95, seed=101))
+
+    # Parallel example
+    psp = copy.deepcopy(sp)
+    (psp.sample_saltelli(2**8)
+        .evaluate_parallel(Ishigami.evaluate, nprocs=2)
+        .analyze_sobol(calc_second_order=True, conf_level=0.95, nprocs=2, seed=101))
+
+    assert np.testing.assert_equal(sp.results, psp.results) is None, "Model results not equal!"
+    assert np.testing.assert_equal(sp.analysis, psp.analysis) is None, "Analysis results not equal!"
+
+
+def test_parallel_multi_output():
+    from SALib.test_functions import lake_problem
+
+    # Create the SALib Problem specification
+    sp = ProblemSpec({
+        'names': ['a', 'q', 'b', 'mean', 'stdev', 'delta', 'alpha'],
+        'bounds': [[0.0, 0.1],
+                   [2.0, 4.5],
+                   [0.1, 0.45],
+                   [0.01, 0.05],
+                   [0.001, 0.005],
+                   [0.93, 0.99],
+                   [0.2, 0.5]],
+        'outputs': ['max_P', 'Utility', 'Inertia', 'Reliability']
+    })
+
+    # Single core example
+    (sp.sample_saltelli(2**8)
+        .evaluate(lake_problem.evaluate)
+        .analyze_sobol(calc_second_order=True, conf_level=0.95, seed=101))
+
+    # Parallel example
+    psp = copy.deepcopy(sp)
+    (psp.sample_saltelli(2**8)
+        .evaluate_parallel(lake_problem.evaluate, nprocs=2)
+        .analyze_sobol(calc_second_order=True, conf_level=0.95, nprocs=2, seed=101))
+
+    assert np.testing.assert_equal(sp.results, psp.results) is None, "Model results not equal!"
+    assert np.testing.assert_equal(sp.analysis, psp.analysis) is None, "Analysis results not equal!"


### PR DESCRIPTION
Adds an `analyze_parallel` method, and cleans up REPL representation.

This PR is currently in progress, tests to ensure results are identical to the sequential approach are being finalized.

Closes #456 

UPDATE: 

This PR incorporates several inter-related changes which I did a poor job of keeping separate. Given the related nature of the changes however, I think it is acceptable.

1. The base `evaluate` and `analyze` methods now support the `nprocs` keyword argument. If provided, the method simply redirects the call to the `evaluate_parallel` and `analyze_parallel` methods. The motivation for maintaining the separation is primarily to reduce code clutter.
2.  Use of processors is capped to the available/detected cores (for model evaluation) and number of outputs (for analysis). i.e., no benefit if there is only a single `Y`.
3. Initial move towards the now recommended `default_rng()` function to produce method/context specific random seeds. This contrasts the earlier usage of `np.random.seed()` which sets global state which can cause issues. This is only completed for the `sobol.analyze` function.
4. Expanded examples/documentation where appropriate
5. Example `lake_problem` adjusted to accept a seed value

As with most parallel solutions, the benefit only becomes obvious when applied to sufficiently long running models or large datasets.

Example:

```python
from SALib.test_functions import lake_problem
from SALib import ProblemSpec


sp = ProblemSpec({
    'names': ['a', 'q', 'b', 'mean', 'stdev', 'delta', 'alpha'],
    'bounds': [[0.0, 0.1], [2.0, 4.5], [0.1, 0.45], [0.01, 0.05], [0.001, 0.005], [0.93, 0.99], [0.2, 0.5]],
    'outputs': ['max_P', 'Utility', 'Inertia', 'Reliability']
})

(sp.sample_saltelli(2**15)
    .evaluate(lake_problem.evaluate, nprocs=2)
    .analyze_sobol(nprocs=2, seed=101))

print(sp)
```

@jdherman @willu47 either of you keen to do a code review, or happy for this to be merged into v1.4.1 directly?