### PR TITLE
Improve listing of compatible sampling methods

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -40,15 +40,21 @@ Or in the `problem` dictionary:
 
 But the output is printed by group:
 ::
+                ST   ST_conf
+    Group_1  0.555309  0.084058
+    Group_2  0.684332  0.057449
+                S1   S1_conf
+    Group_1  0.316696  0.056797
+    Group_2  0.456497  0.079049
+                            S2   S2_conf
+    (Group_1, Group_2)  0.238909  0.127195
 
-               ST   ST_conf
-Group_1  0.555309  0.084058
-Group_2  0.684332  0.057449
-               S1   S1_conf
-Group_1  0.316696  0.056797
-Group_2  0.456497  0.079049
-                          S2   S2_conf
-(Group_1, Group_2)  0.238909  0.127195
+
+The output can then be converted to a Pandas DataFrame for further analysis.
+
+.. code:: python
+
+    total_Si, first_Si, second_Si = Si.to_df()
 
 
 Generating alternate distributions

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,7 @@ FAST - Fourier Amplitude Sensitivity Test
 .. autofunction:: SALib.sample.fast_sampler.sample
    :noindex:
 
+
 .. autofunction:: SALib.analyze.fast.analyze
    :noindex:
 
@@ -18,6 +19,7 @@ RBD-FAST - Random Balance Designs Fourier Amplitude Sensitivity Test
 
 .. autofunction:: SALib.sample.latin.sample
    :noindex:
+
 
 .. autofunction:: SALib.analyze.rbd_fast.analyze
    :noindex:
@@ -28,14 +30,16 @@ Method of Morris
 .. autofunction:: SALib.sample.morris.sample
    :noindex:
 
+
 .. autofunction:: SALib.analyze.morris.analyze
    :noindex:
 
-Sobol Sensitivity Analysis
+Sobol' Sensitivity Analysis
 --------------------------
 
 .. autofunction:: SALib.sample.saltelli.sample
    :noindex:
+
 
 .. autofunction:: SALib.analyze.sobol.analyze
    :noindex:
@@ -45,6 +49,7 @@ Delta Moment-Independent Measure
 
 .. autofunction:: SALib.sample.latin.sample
    :noindex:
+
 
 .. autofunction:: SALib.analyze.delta.analyze
    :noindex:
@@ -61,11 +66,18 @@ Fractional Factorial
 .. autofunction:: SALib.sample.ff.sample
    :noindex:
 
+
 .. autofunction:: SALib.analyze.ff.analyze
+   :noindex:
+
+PAWN Sensitivity Analysis
+-------------------------
+
+.. autofunction:: SALib.analyze.pawn.analyze
    :noindex:
 
 High-Dimensional Model Representation
 -------------------------------------
 
-.. autofunction:: SALib.analyze.ff.hdmr
+.. autofunction:: SALib.analyze.hdmr.analyze
    :noindex:

--- a/src/SALib/analyze/delta.py
+++ b/src/SALib/analyze/delta.py
@@ -16,9 +16,12 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
     where each entry is a list of size D (the number of parameters) containing
     the indices in the same order as the parameter file.
 
-    Compatible with
-    ---------------
-    all samplers
+
+    Notes
+    -----
+    Compatible with:
+        all samplers
+
 
     Parameters
     ----------
@@ -35,6 +38,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
     print_to_console : bool
         Print results directly to console (default False)
 
+
     References
     ----------
     .. [1] Borgonovo, E. (2007). "A new uncertainty importance measure."
@@ -44,6 +48,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
     .. [2] Plischke, E., E. Borgonovo, and C. L. Smith (2013). "Global
            sensitivity measures from given data." European Journal of
            Operational Research, 226(3):536-550, doi:10.1016/j.ejor.2012.11.047.
+
 
     Examples
     --------

--- a/src/SALib/analyze/delta.py
+++ b/src/SALib/analyze/delta.py
@@ -18,7 +18,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
 
     Compatible with
     ---------------
-    * all samplers
+    all samplers
 
     Parameters
     ----------

--- a/src/SALib/analyze/dgsm.py
+++ b/src/SALib/analyze/dgsm.py
@@ -14,9 +14,12 @@ def analyze(problem, X, Y, num_resamples=100,
     where each entry is a list of size D (the number of parameters) containing
     the indices in the same order as the parameter file.
 
-    Compatible with
-    ---------------
-    * `finite_diff`
+
+    Notes
+    -----
+    Compatible with:
+        `finite_diff` : :func:`SALib.sample.finite_diff.sample`
+
 
     Parameters
     ----------
@@ -34,12 +37,19 @@ def analyze(problem, X, Y, num_resamples=100,
     print_to_console : bool
         Print results directly to console (default False)
 
+
     References
     ----------
     .. [1] Sobol, I. M. and S. Kucherenko (2009). "Derivative based global
            sensitivity measures and their link with global sensitivity
            indices." Mathematics and Computers in Simulation, 79(10):3009-3017,
            doi:10.1016/j.matcom.2009.01.023.
+
+    Examples
+    --------
+        >>> X = finite_diff.sample(problem, 1000)
+        >>> Y = Ishigami.evaluate(X)
+        >>> Si = dgsm.analyze(problem, Y, print_to_console=False)
     """
     if seed:
         np.random.seed(seed)
@@ -86,7 +96,7 @@ def analyze(problem, X, Y, num_resamples=100,
                                                     bounds[j],
                                                     num_resamples,
                                                     conf_level)
-    
+
     if print_to_console:
         print(S.to_df())
 
@@ -95,7 +105,7 @@ def analyze(problem, X, Y, num_resamples=100,
 
 def calc_vi_stats(base, perturbed, x_delta):
     """Calculate v_i mean and std.
-    
+
     v_i sensitivity measure following Sobol and Kucherenko (2009)
     For comparison, Morris mu* < sqrt(v_i)
 

--- a/src/SALib/analyze/fast.py
+++ b/src/SALib/analyze/fast.py
@@ -15,7 +15,7 @@ def analyze(problem, Y, M=4, num_resamples=100, conf_level=0.95, print_to_consol
 
     Compatible with
     ---------------
-    * `fast_sampler`
+    `fast_sampler` : :func:`SALib.sample.fast_sampler.sample`
 
     Parameters
     ----------

--- a/src/SALib/analyze/fast.py
+++ b/src/SALib/analyze/fast.py
@@ -13,9 +13,12 @@ def analyze(problem, Y, M=4, num_resamples=100, conf_level=0.95, print_to_consol
     size D (the number of parameters) containing the indices in the same order
     as the parameter file.
 
-    Compatible with
-    ---------------
-    `fast_sampler` : :func:`SALib.sample.fast_sampler.sample`
+
+    Notes
+    -----
+    Compatible with:
+        `fast_sampler` : :func:`SALib.sample.fast_sampler.sample`
+
 
     Parameters
     ----------
@@ -28,6 +31,7 @@ def analyze(problem, Y, M=4, num_resamples=100, conf_level=0.95, print_to_consol
         the Fourier series decomposition (default 4)
     print_to_console : bool
         Print results directly to console (default False)
+
 
     References
     ----------
@@ -45,11 +49,12 @@ def analyze(problem, Y, M=4, num_resamples=100, conf_level=0.95, print_to_consol
            fast99 - R `sensitivity` package
            https://github.com/cran/sensitivity/blob/master/R/fast99.R
 
+
     Examples
     --------
-    >>> X = fast_sampler.sample(problem, 1000)
-    >>> Y = Ishigami.evaluate(X)
-    >>> Si = fast.analyze(problem, Y, print_to_console=False)
+        >>> X = fast_sampler.sample(problem, 1000)
+        >>> Y = Ishigami.evaluate(X)
+        >>> Si = fast.analyze(problem, Y, print_to_console=False)
     """
     if seed:
         np.random.seed(seed)

--- a/src/SALib/analyze/ff.py
+++ b/src/SALib/analyze/ff.py
@@ -23,9 +23,12 @@ def analyze(problem, X, Y, second_order=False, print_to_console=False,
     parameters to the nearest 2**n.  Any results involving dummy parameters
     could indicate a problem with the model runs.
 
-    Compatible with
-    ---------------
-    `ff` : :func:`SALib.sample.ff.sample`
+
+    Notes
+    -----
+    Compatible with:
+        `ff` : :func:`SALib.sample.ff.sample`
+
 
     Parameters
     ----------
@@ -40,11 +43,13 @@ def analyze(problem, X, Y, second_order=False, print_to_console=False,
     print_to_console: bool, default=False
         Print results directly to console
 
+
     Returns
     -------
     Si: dict
         A dictionary of sensitivity indices, including main effects ``ME``,
         and interaction effects ``IE`` (if ``second_order`` is True)
+
 
     References
     ----------
@@ -54,11 +59,12 @@ def analyze(problem, X, Y, second_order=False, print_to_console=False,
            Wiley, West Sussex, U.K.
            https://dx.doi.org/10.1002/9780470725184
 
+
     Examples
     --------
-    >>> X = sample(problem)
-    >>> Y = X[:, 0] + (0.1 * X[:, 1]) + ((1.2 * X[:, 2]) * (0.2 + X[:, 0]))
-    >>> analyze(problem, X, Y, second_order=True, print_to_console=True)
+        >>> X = sample(problem)
+        >>> Y = X[:, 0] + (0.1 * X[:, 1]) + ((1.2 * X[:, 2]) * (0.2 + X[:, 0]))
+        >>> analyze(problem, X, Y, second_order=True, print_to_console=True)
     """
     if seed:
         np.random.seed(seed)

--- a/src/SALib/analyze/ff.py
+++ b/src/SALib/analyze/ff.py
@@ -25,7 +25,7 @@ def analyze(problem, X, Y, second_order=False, print_to_console=False,
 
     Compatible with
     ---------------
-    * `ff`
+    `ff` : :func:`SALib.sample.ff.sample`
 
     Parameters
     ----------

--- a/src/SALib/analyze/hdmr.py
+++ b/src/SALib/analyze/hdmr.py
@@ -29,7 +29,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
     - a N x d matrix of N different d-vectors of model inputs (factors/parameters)
     - a N x 1 vector of corresponding model outputs
 
-    Returns to the user:
+    Returns:
     - each factor's first, second, and third order sensitivity coefficient
       (separated in total, structural and correlative contributions), 
     - an estimate of their 95% confidence intervals (from bootstrap method)
@@ -44,9 +44,14 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
       to a single index (= structural contribution), consistent with their
       values derived from commonly used variance-based GSA methods.
 
-    Compatible with
-    ---------------
-    all samplers
+
+    Notes
+    -----
+    Compatible with:
+        all samplers
+
+    Contributed by @sahin-abdullah (sahina@uci.edu)
+
 
     Parameters
     ----------
@@ -59,7 +64,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
     Y : numpy.array
         The NumPy array containing the model outputs for each row of X
 
-    maxorder : int (1-3, default: 2) 
+    maxorder : int (1-3, default: 2)
         Maximum HDMR expansion order
 
     maxiter : int (1-1000, default: 100)
@@ -82,9 +87,10 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
 
     print_to_console : bool
         Print results directly to console (default False)
-    
+
     seed : bool
         Set a seed value
+
 
     Returns
     -------
@@ -100,9 +106,10 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
         Sa: Uncorrelated contribution
         select: Number of selection (F-Test)
         Em: Result set
-            C1: First order coefficient 
+            C1: First order coefficient
             C2: Second order coefficient
             C3: Third Order coefficient
+
 
     References
     ----------
@@ -111,16 +118,13 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
             Systems with Independent and/or Correlated Inputs", Journal of
             Physical Chemistry A, Vol. 114 (19), pp. 6022 - 6032, 2010,
             https://doi.org/10.1021/jp9096919
-       
+
+
     Examples
     --------
         >>> X = saltelli.sample(problem, 512)
         >>> Y = Ishigami.evaluate(X)
         >>> Si = hdmr.analyze(problem, X, Y, **options)
-
-    Contributed by
-    --------------
-        @sahin-abdullah (sahina@uci.edu)
     """
     # Random Seed
     if seed:

--- a/src/SALib/analyze/hdmr.py
+++ b/src/SALib/analyze/hdmr.py
@@ -46,7 +46,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
 
     Compatible with
     ---------------
-    * all samplers
+    all samplers
 
     Parameters
     ----------

--- a/src/SALib/analyze/morris.py
+++ b/src/SALib/analyze/morris.py
@@ -19,7 +19,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
 
     Compatible with
     ---------------
-    * `morris`
+    `morris` : :func:`SALib.sample.morris.sample`
 
     Parameters
     ----------

--- a/src/SALib/analyze/morris.py
+++ b/src/SALib/analyze/morris.py
@@ -17,9 +17,12 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
     'mu_star_conf', where each entry is a list of parameters containing
     the indices in the same order as the parameter file.
 
-    Compatible with
-    ---------------
-    `morris` : :func:`SALib.sample.morris.sample`
+
+    Notes
+    -----
+    Compatible with:
+        `morris` : :func:`SALib.sample.morris.sample`
+
 
     Parameters
     ----------
@@ -42,6 +45,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
     seed : int
         Seed to generate a random number
 
+
     Returns
     -------
     Si : dict
@@ -52,6 +56,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
         - `sigma` - the standard deviation of the elementary effect
         - `mu_star_conf` - the bootstrapped confidence interval
         - `names` - the names of the parameters
+
 
     References
     ----------
@@ -64,13 +69,13 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray,
            Environmental Modelling & Software, 22(10):1509-1518,
            doi:10.1016/j.envsoft.2006.10.004.
 
+
     Examples
     --------
-    >>> X = morris.sample(problem, 1000, num_levels=4)
-    >>> Y = Ishigami.evaluate(X)
-    >>> Si = morris.analyze(problem, X, Y, conf_level=0.95,
-    >>>                     print_to_console=True, num_levels=4)
-
+        >>> X = morris.sample(problem, 1000, num_levels=4)
+        >>> Y = Ishigami.evaluate(X)
+        >>> Si = morris.analyze(problem, X, Y, conf_level=0.95,
+        >>>                     print_to_console=True, num_levels=4)
     """
     if seed:
         np.random.seed(seed)

--- a/src/SALib/analyze/pawn.py
+++ b/src/SALib/analyze/pawn.py
@@ -20,7 +20,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray, S: int = 10,
 
     Compatible with
     ---------------
-    * all samplers
+    all samplers
 
     Notes
     -----

--- a/src/SALib/analyze/pawn.py
+++ b/src/SALib/analyze/pawn.py
@@ -15,16 +15,18 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray, S: int = 10,
 
     Calculates the min, mean, median, max, and coefficient of variation (CV).
 
-    CV is (standard deviation / mean), and so lower values indicate little change
-    over the slides, and larger values indicate large variations across the slides.
+    CV is (standard deviation / mean), and so lower values indicate little
+    change over the slides, and larger values indicate large variations across
+    the slides.
 
-    Compatible with
-    ---------------
-    all samplers
 
     Notes
     -----
+    Compatible with:
+        all samplers
+
     This implementation ignores all NaNs.
+
 
     Parameters
     ----------
@@ -40,6 +42,7 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray, S: int = 10,
         Print results directly to console (default False)
     seed : int
         Seed value to ensure deterministic results
+
 
     References
     ----------
@@ -65,11 +68,12 @@ def analyze(problem: Dict, X: np.ndarray, Y: np.ndarray, S: int = 10,
            Combining variance- and distribution-based global sensitivity analysis
            https://github.com/baronig/GSA-cvd
 
+
     Examples
     --------
-    >>> X = latin.sample(problem, 1000)
-    >>> Y = Ishigami.evaluate(X)
-    >>> Si = pawn.analyze(problem, X, Y, S=10, print_to_console=False)
+        >>> X = latin.sample(problem, 1000)
+        >>> Y = Ishigami.evaluate(X)
+        >>> Si = pawn.analyze(problem, X, Y, S=10, print_to_console=False)
     """
     if seed:
         np.random.seed(seed)

--- a/src/SALib/analyze/rbd_fast.py
+++ b/src/SALib/analyze/rbd_fast.py
@@ -19,7 +19,7 @@ def analyze(problem, X, Y, M=10, num_resamples=100, conf_level=0.95, print_to_co
 
     Compatible with
     ---------------
-    * all samplers
+    all samplers
 
     Parameters
     ----------

--- a/src/SALib/analyze/rbd_fast.py
+++ b/src/SALib/analyze/rbd_fast.py
@@ -17,9 +17,11 @@ def analyze(problem, X, Y, M=10, num_resamples=100, conf_level=0.95, print_to_co
     size D (the number of parameters) containing the indices in the same order
     as the parameter file.
 
-    Compatible with
-    ---------------
-    all samplers
+    Notes
+    -----
+    Compatible with:
+        all samplers
+
 
     Parameters
     ----------
@@ -34,6 +36,7 @@ def analyze(problem, X, Y, M=10, num_resamples=100, conf_level=0.95, print_to_co
         the Fourier series decomposition (default 10)
     print_to_console : bool
         Print results directly to console (default False)
+
 
     References
     ----------
@@ -56,11 +59,12 @@ def analyze(problem, X, Y, M=10, num_resamples=100, conf_level=0.95, print_to_co
           Journal of Building Performance Simulation.
           doi:10.1080/19401493.2015.1112430
 
+
     Examples
     --------
-    >>> X = latin.sample(problem, 1000)
-    >>> Y = Ishigami.evaluate(X)
-    >>> Si = rbd_fast.analyze(problem, X, Y, print_to_console=False)
+        >>> X = latin.sample(problem, 1000)
+        >>> Y = Ishigami.evaluate(X)
+        >>> Si = rbd_fast.analyze(problem, X, Y, print_to_console=False)
     """
     if seed:
         np.random.seed(seed)

--- a/src/SALib/analyze/sobol.py
+++ b/src/SALib/analyze/sobol.py
@@ -23,9 +23,13 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
     indices in the same order as the parameter file.  If calc_second_order is
     True, the dictionary also contains keys 'S2' and 'S2_conf'.
 
-    Compatible with
-    ---------------
-    `saltelli` : :func:`SALib.sample.saltelli.sample`
+
+    Notes
+    -----
+    Compatible with:
+        `saltelli` : :func:`SALib.sample.saltelli.sample`
+
+
 
     Parameters
     ----------
@@ -44,6 +48,7 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
     keep_resamples : bool
         Whether or not to store intermediate resampling results (default False)
 
+
     References
     ----------
     .. [1] Sobol, I. M. (2001).  "Global sensitivity indices for nonlinear
@@ -59,12 +64,12 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
            Computer Physics Communications, 181(2):259-270,
            doi:10.1016/j.cpc.2009.09.018.
 
+
     Examples
     --------
-    >>> X = saltelli.sample(problem, 512)
-    >>> Y = Ishigami.evaluate(X)
-    >>> Si = sobol.analyze(problem, Y, print_to_console=True)
-
+        >>> X = saltelli.sample(problem, 512)
+        >>> Y = Ishigami.evaluate(X)
+        >>> Si = sobol.analyze(problem, Y, print_to_console=True)
     """
     if seed:
         # Set seed to ensure CIs are the same

--- a/src/SALib/analyze/sobol.py
+++ b/src/SALib/analyze/sobol.py
@@ -25,7 +25,7 @@ def analyze(problem, Y, calc_second_order=True, num_resamples=100,
 
     Compatible with
     ---------------
-    * `saltelli`
+    `saltelli` : :func:`SALib.sample.saltelli.sample`
 
     Parameters
     ----------

--- a/src/SALib/sample/finite_diff.py
+++ b/src/SALib/sample/finite_diff.py
@@ -7,7 +7,7 @@ from . import sobol_sequence
 from ..util import scale_samples, read_param_file
 
 
-def sample(problem: Dict, N: int, delta: float = 0.01, 
+def sample(problem: Dict, N: int, delta: float = 0.01,
            seed: int = None, skip_values: int = 1024) -> np.ndarray:
     """Generate matrix of samples for derivative-based global sensitivity measure (dgsm).
     Start from a QMC (Sobol') sequence and finite difference with delta % steps
@@ -22,7 +22,7 @@ def sample(problem: Dict, N: int, delta: float = 0.01,
 
     delta : float
         Finite difference step size (percent)
-    
+
     seed : int or None
         Random seed value
 
@@ -35,15 +35,15 @@ def sample(problem: Dict, N: int, delta: float = 0.01,
 
     References
     ----------
-    .. [1] Sobol', I.M., Kucherenko, S., 2009. 
-           Derivative based global sensitivity measures and their link with 
-           global sensitivity indices. 
-           Mathematics and Computers in Simulation 79, 3009–3017. 
+    .. [1] Sobol', I.M., Kucherenko, S., 2009.
+           Derivative based global sensitivity measures and their link with
+           global sensitivity indices.
+           Mathematics and Computers in Simulation 79, 3009–3017.
            https://doi.org/10.1016/j.matcom.2009.01.023
 
-    .. [2] Sobol', I.M., Kucherenko, S., 2010. 
-           Derivative based global sensitivity measures. 
-           Procedia - Social and Behavioral Sciences 2, 7745–7746. 
+    .. [2] Sobol', I.M., Kucherenko, S., 2010.
+           Derivative based global sensitivity measures.
+           Procedia - Social and Behavioral Sciences 2, 7745–7746.
            https://doi.org/10.1016/j.sbspro.2010.05.208
 
     """

--- a/src/SALib/test_functions/lake_problem.py
+++ b/src/SALib/test_functions/lake_problem.py
@@ -6,31 +6,37 @@ from scipy.optimize import brentq
 
 FLOAT_OR_ARRAY = Union[float, np.array]
 
-def lake_problem(X: FLOAT_OR_ARRAY, a: FLOAT_OR_ARRAY = 0.1, q: FLOAT_OR_ARRAY = 2.0, 
+
+def lake_problem(X: FLOAT_OR_ARRAY, a: FLOAT_OR_ARRAY = 0.1,
+                 q: FLOAT_OR_ARRAY = 2.0,
                  b: FLOAT_OR_ARRAY = 0.42,
                  eps: FLOAT_OR_ARRAY = 0.02) -> float:
-    """Lake Problem as given in [1] and [2] modified for use as a test function.
+    """Lake Problem as given in Hadka et al., (2015) and Kwakkel (2017)
+    modified for use as a test function.
 
     The `mean` and `stdev` parameters control the log normal distribution of
     natural inflows (`epsilon` in [1] and [2]).
 
+    References
+    ----------
     .. [1] Hadka, D., Herman, J., Reed, P., Keller, K., (2015).
-           "An open source framework for many-objective robust decision making."
-           Environmental Modelling & Software 74, 114–129. 
+           "An open source framework for many-objective robust decision
+                making."
+           Environmental Modelling & Software 74, 114–129.
            doi:10.1016/j.envsoft.2015.07.014
-    
-    .. [2] Kwakkel, J.H, (2017). "The Exploratory Modeling Workbench: An open 
-           source toolkit for exploratory modeling, scenario discovery, and 
+
+    .. [2] Kwakkel, J.H, (2017). "The Exploratory Modeling Workbench: An open
+           source toolkit for exploratory modeling, scenario discovery, and
            (multi-objective) robust decision making."
-           Environmental Modelling & Software 96, 239–250. 
+           Environmental Modelling & Software 96, 239–250.
            doi:10.1016/j.envsoft.2017.06.054
 
-    .. [3] Singh, R., Reed, P., Keller, K., (2015). "Many-objective robust 
-           decision making for managing an ecosystem with a deeply uncertain 
+    .. [3] Singh, R., Reed, P., Keller, K., (2015). "Many-objective robust
+           decision making for managing an ecosystem with a deeply uncertain
            threshold response."
-           Ecology and Society 20. 
+           Ecology and Society 20.
            doi:10.5751/ES-07687-200312
-    
+
     Parameters
     ----------
     X : float or np.ndarray
@@ -58,24 +64,27 @@ def lake_problem(X: FLOAT_OR_ARRAY, a: FLOAT_OR_ARRAY = 0.1, q: FLOAT_OR_ARRAY =
 def evaluate_lake(values: np.ndarray, seed=101) -> np.ndarray:
     """Evaluate the Lake Problem with an array of parameter values.
 
+    References
+    ----------
     .. [1] Hadka, D., Herman, J., Reed, P., Keller, K., (2015).
-           "An open source framework for many-objective robust decision making."
-           Environmental Modelling & Software 74, 114–129. 
+           "An open source framework for many-objective robust decision
+                making."
+           Environmental Modelling & Software 74, 114–129.
            doi:10.1016/j.envsoft.2015.07.014
 
-    .. [2] Singh, R., Reed, P., Keller, K., (2015). "Many-objective robust 
-           decision making for managing an ecosystem with a deeply uncertain 
+    .. [2] Singh, R., Reed, P., Keller, K., (2015). "Many-objective robust
+           decision making for managing an ecosystem with a deeply uncertain
            threshold response."
-           Ecology and Society 20. 
+           Ecology and Society 20.
            doi:10.5751/ES-07687-200312
 
     Parameters
     ----------
-    values : np.ndarray, 
+    values : np.ndarray,
              model inputs in the (column) order of
              a, q, b, mean, stdev
 
-             where 
+             where
              * `a` is rate of anthropogenic pollution
              * `q` is exponent controlling recycling rate
              * `b` is decay rate for phosphorus
@@ -100,7 +109,8 @@ def evaluate_lake(values: np.ndarray, seed=101) -> np.ndarray:
 
     Y = np.zeros((nvars, nvars))
     for t in range(nvars):
-        # First X value will be last Y value (should be 0 as we are filling an array of zeros)
+        # First X value will be last Y value (should be 0 as we are filling
+        # an array of zeros)
         Y[t] = lake_problem(Y[t-1], a, q, b, eps)
 
     return Y
@@ -111,13 +121,13 @@ def evaluate(values: np.ndarray, nvars: int = 100, seed=101):
 
     Parameters
     ----------
-    values : np.ndarray, 
+    values : np.ndarray,
              model inputs in the (column) order of
              a, q, b, mean, stdev, delta, alpha
 
-    nvars : int, 
+    nvars : int,
             number of decision variables to simulate (default: 100)
-    
+
 
     Returns
     -------
@@ -161,7 +171,8 @@ if __name__ == '__main__':
     LAKE_SPEC = {
         'num_vars': 7,
         'names': ['a', 'q', 'b', 'mean', 'stdev', 'delta', 'alpha'],
-        'bounds': [[0.0, 0.1], [2.0, 4.5], [0.1, 0.45], [0.01, 0.05], [0.001, 0.005], [0.93, 0.99], [0.2, 0.5]],
+        'bounds': [[0.0, 0.1], [2.0, 4.5], [0.1, 0.45], [0.01, 0.05],
+                   [0.001, 0.005], [0.93, 0.99], [0.2, 0.5]],
         'outputs': ['max_P', 'Utility', 'Inertia', 'Reliability']
     }
 


### PR DESCRIPTION
Noticed that the compatible methods are not correctly displayed when rendered on readthedocs:

```
Compatible with
------------------
* `morris`
```

![image](https://user-images.githubusercontent.com/4075136/134747607-73d3bb70-a294-46dc-b70a-4508f9e9d983.png)

Turns out Sphinx pre-defines section headers and does not render custom ones.
To resolve this, I've merged the listings under the "Notes" section.

I plan to place further text on method caveats, pitfalls, and other useful information (as done for the Saltelli method).

```
Notes
-----
Compatible with:
    `morris` : :func:`SALib.sample.morris.sample`
```

PR includes miscellaneous clean up (primarily removing whitespace, and other changes to conform to PEP8).
