### PR TITLE
Raise error when a single parameter/group is detected [OO-based only]

### DIFF
--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -38,6 +38,8 @@ class ProblemSpec(dict):
         self._analysis = None
 
         self['num_vars'] = len(self['names'])
+        if 'groups' not in self:
+            self['groups'] = None
 
         self._add_samplers()
         self._add_analyzers()

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -276,7 +276,6 @@ class ProblemSpec(dict):
 
         return self
 
-
     def analyze(self, func, *args, **kwargs):
         """Analyze sampled results using given function.
 
@@ -300,6 +299,14 @@ class ProblemSpec(dict):
         ----------
         self : ProblemSpec object
         """
+        if self['num_vars'] == 1 or (self['groups'] and len('groups') == 1):
+            msg = (
+                "There is only a single parameter or group defined. There is "
+                "no point in conducting sensitivity analysis as any and all"
+                "effect(s) will be mapped to the single parameter/group."
+            )
+            raise ValueError(msg)
+
         if 'nprocs' in kwargs:
             # Call parallel method instead
             return self.analyze_parallel(func, *args, **kwargs)

--- a/tests/test_problem_spec.py
+++ b/tests/test_problem_spec.py
@@ -139,3 +139,41 @@ def test_parallel_multi_output():
 
     assert np.testing.assert_equal(sp.results, psp.results) is None, "Model results not equal!"
     assert np.testing.assert_equal(sp.analysis, psp.analysis) is None, "Analysis results not equal!"
+
+
+
+def test_single_parameter():
+    """Ensures error is raised when attempting to conduct SA on a single parameter."""
+
+    sp = ProblemSpec({
+        'names': ['x1'],
+        'bounds': [[-1, 1]],
+        'outputs': ['Y']
+    })
+
+    def func(X):
+        return X[1] * X[0]
+
+    sp.sample_latin(50)
+    sp.evaluate(func)
+
+    with pytest.raises(ValueError):
+        sp.analyze_hdmr()
+
+def test_single_group():
+    """Ensures error is raised when attempting to conduct SA on a single group."""
+    sp = ProblemSpec({
+        'names': ['x1'],
+        'bounds': [[-1, 1]],
+        'groups': ['G1'],
+        'outputs': ['Y']
+    })
+
+    def func(X):
+        return X[1] * X[0]
+
+    sp.sample_latin(50)
+    sp.evaluate(func)
+
+    with pytest.raises(ValueError):
+        sp.analyze_hdmr()


### PR DESCRIPTION
Resolves #483 

Raises error to alert user that there is no point in conducting SA for a single parameter.

This targets OO-based interface only.