### PR TITLE
Better Triangular Distribution

### DIFF
--- a/README-advanced.md
+++ b/README-advanced.md
@@ -124,11 +124,13 @@ parameter bounds but sample-specific metadata.
 
 * unif: uniform distribution
     e.g. :code:`[-np.pi, np.pi]` defines the lower and upper bounds
-* triang: triangular with width (scale) and location of peak. 
-    Location of peak is in percentage of width.
-    Lower bound assumed to be zero.
+* triang: triangular with lower and upper bounds, as well as
+     location of peak
+     The location of peak is in percentage of width
+     e.g. :code:`[1.0, 3.0, 0.5]` indicates 1.0 to 3.0 with a peak at 2.0
 
-    e.g. :code:`[3, 0.5]` assumes 0 to 3, with a peak at 1.5
+     A deprecated two-value format assumes the lower bound to be 0
+     e.g. :code:`[3, 0.5]` assumes 0 to 3, with a peak at 1.5
 * norm: normal distribution with mean and standard deviation
 * lognorm: lognormal with ln-space mean and standard deviation
 

--- a/README-advanced.md
+++ b/README-advanced.md
@@ -129,7 +129,7 @@ parameter bounds but sample-specific metadata.
      The location of peak is in percentage of width
      e.g. :code:`[1.0, 3.0, 0.5]` indicates 1.0 to 3.0 with a peak at 2.0
 
-     A deprecated two-value format assumes the lower bound to be 0
+     A soon-to-be deprecated two-value format assumes the lower bound to be 0
      e.g. :code:`[3, 0.5]` assumes 0 to 3, with a peak at 1.5
 * norm: normal distribution with mean and standard deviation
 * lognorm: lognormal with ln-space mean and standard deviation

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -91,11 +91,13 @@ parameter bounds but sample-specific metadata.
 
 * unif: uniform distribution
     e.g. :code:`[-np.pi, np.pi]` defines the lower and upper bounds
-* triang: triangular with width (scale) and location of peak. 
-    Location of peak is in percentage of width.
-    Lower bound assumed to be zero.
+* triang: triangular with lower and upper bounds, as well as
+     location of peak
+     The location of peak is in percentage of width
+     e.g. :code:`[1.0, 3.0, 0.5]` indicates 1.0 to 3.0 with a peak at 2.0
 
-    e.g. :code:`[3, 0.5]` assumes 0 to 3, with a peak at 1.5
+     A deprecated two-value format assumes the lower bound to be 0
+     e.g. :code:`[3, 0.5]` assumes 0 to 3, with a peak at 1.5
 * norm: normal distribution with mean and standard deviation
 * lognorm: lognormal with ln-space mean and standard deviation
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -96,7 +96,7 @@ parameter bounds but sample-specific metadata.
      The location of peak is in percentage of width
      e.g. :code:`[1.0, 3.0, 0.5]` indicates 1.0 to 3.0 with a peak at 2.0
 
-     A deprecated two-value format assumes the lower bound to be 0
+     A soon-to-be deprecated two-value format assumes the lower bound to be 0
      e.g. :code:`[3, 0.5]` assumes 0 to 3, with a peak at 1.5
 * norm: normal distribution with mean and standard deviation
 * lognorm: lognormal with ln-space mean and standard deviation

--- a/src/SALib/util/__init__.py
+++ b/src/SALib/util/__init__.py
@@ -4,6 +4,7 @@
 from collections import OrderedDict
 import pkgutil
 from typing import Dict, Tuple
+import warnings
 
 import numpy as np  # type: ignore
 import scipy as sp  # type: ignore
@@ -151,9 +152,25 @@ def _nonuniform_scale_samples(params, bounds, dists):
         b2 = b[i][1]  # 0-1
 
         if dists[i] == 'triang':
-            loc_start = b[i][0]  # loc start
-            b1 = b[i][1]  # triangular distribution end
-            b2 = b[i][2]  # 0-1 aka c
+            if len(b[i]) == 3:
+                loc_start = b[i][0]  # loc start
+                b1 = b[i][1]  # triangular distribution end
+                b2 = b[i][2]  # 0-1 aka c
+            elif len(b[i]) == 2:
+                msg = ("Two-value format for triangular distributions detected.\n"
+                    "To remove this message, specify the distribution start, "
+                    "end, and peak (three values) "
+                    "instead of the current two-value format "
+                    "(distribution end and peak, with start assumed to be 0)\n"
+                    "The two-value format will be deprecated in SALib v1.5"
+                )
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+                loc_start = 0
+                b1 = b[i][0]
+                b2 = b[i][1]
+            else:
+                raise ValueError("Unknown triangular distribution specification. Check problem specification.")
 
             # checking for correct parameters
             if b1 <= 0 or b2 <= 0 or b2 >= 1 or loc_start > b1:

--- a/src/SALib/util/__init__.py
+++ b/src/SALib/util/__init__.py
@@ -10,7 +10,8 @@ import scipy as sp  # type: ignore
 from scipy import stats
 from typing import List
 
-from .util_funcs import (avail_approaches, read_param_file, _check_bounds, _check_groups)
+from .util_funcs import (
+    avail_approaches, read_param_file, _check_bounds, _check_groups)
 from .problem import ProblemSpec
 from .results import ResultDict
 
@@ -35,7 +36,8 @@ def _scale_samples(params: np.ndarray, bounds: List):
     lower_bounds, upper_bounds = _check_bounds(bounds)
 
     if np.any(lower_bounds >= upper_bounds):
-        raise ValueError("Bounds are not legal (upper bound must be greater than lower bound)")
+        raise ValueError(
+            "Bounds are not legal (upper bound must be greater than lower bound)")
 
     # This scales the samples in-place, by using the optional output
     # argument for the numpy ufunctions
@@ -104,7 +106,8 @@ def _unscale_samples(params, bounds):
     upper_bounds = b[:, 1]
 
     if np.any(lower_bounds >= upper_bounds):
-        raise ValueError("Bounds are not legal (upper bound must be greater than lower bound)")
+        raise ValueError(
+            "Bounds are not legal (upper bound must be greater than lower bound)")
 
     # This scales the samples in-place, by using the optional output
     # argument for the numpy ufunctions
@@ -144,17 +147,16 @@ def _nonuniform_scale_samples(params, bounds, dists):
     # loop over the parameters
     for i in range(conv_params.shape[1]):
         # setting first and second arguments for distributions
-        b1 = b[i][0] # ending
-        b2 = b[i][1] #0-1
-        
+        b1 = b[i][0]  # ending
+        b2 = b[i][1]  # 0-1
 
         if dists[i] == 'triang':
-            loc_start = b[i][0] #loc start
-            b1 = b[i][1] #triangular distribution end
-            b2 = b[i][2] # 0-1 aka c
-           
+            loc_start = b[i][0]  # loc start
+            b1 = b[i][1]  # triangular distribution end
+            b2 = b[i][2]  # 0-1 aka c
+
             # checking for correct parameters
-            if b1 <= 0 or b2 <= 0 or b2 >= 1 or loc_start>b1:
+            if b1 <= 0 or b2 <= 0 or b2 >= 1 or loc_start > b1:
                 raise ValueError("""Triangular distribution: Scale must be
                     greater than zero; peak on interval [0,1], triangular start value must be smaller than end value""")
             else:
@@ -223,7 +225,7 @@ def extract_group_names(groups: List) -> Tuple:
     Parameters
     ----------
     groups : List
-        
+
 
     Returns
     -------

--- a/src/SALib/util/__init__.py
+++ b/src/SALib/util/__init__.py
@@ -132,9 +132,9 @@ def _nonuniform_scale_samples(params, bounds, dists):
     dists : list
         list of distributions, one for each parameter
             unif: uniform with lower and upper bounds
-            triang: triangular with width (scale) and location of peak
-                    location of peak is in percentage of width
-                    lower bound assumed to be zero
+            triang: triangular with lower and upper bounds, as well as
+                    location of peak
+                    The location of peak is in percentage of width
             norm: normal distribution with mean and standard deviation
             truncnorm: truncated normal distribution with upper and lower
                     bounds, mean and standard deviation

--- a/src/SALib/util/__init__.py
+++ b/src/SALib/util/__init__.py
@@ -135,6 +135,10 @@ def _nonuniform_scale_samples(params, bounds, dists):
             triang: triangular with lower and upper bounds, as well as
                     location of peak
                     The location of peak is in percentage of width
+                    e.g. :code:`[1.0, 3.0, 0.5]` indicates 1.0 to 3.0 with a peak at 2.0
+
+                    A soon-to-be deprecated two-value format assumes the lower bound to be 0
+                    e.g. :code:`[3, 0.5]` assumes 0 to 3, with a peak at 1.5
             norm: normal distribution with mean and standard deviation
             truncnorm: truncated normal distribution with upper and lower
                     bounds, mean and standard deviation

--- a/src/SALib/util/__init__.py
+++ b/src/SALib/util/__init__.py
@@ -144,17 +144,22 @@ def _nonuniform_scale_samples(params, bounds, dists):
     # loop over the parameters
     for i in range(conv_params.shape[1]):
         # setting first and second arguments for distributions
-        b1 = b[i][0]
-        b2 = b[i][1]
+        b1 = b[i][0] # ending
+        b2 = b[i][1] #0-1
+        
 
         if dists[i] == 'triang':
+            loc_start = b[i][0] #loc start
+            b1 = b[i][1] #triangular distribution end
+            b2 = b[i][2] # 0-1 aka c
+           
             # checking for correct parameters
-            if b1 <= 0 or b2 <= 0 or b2 >= 1:
+            if b1 <= 0 or b2 <= 0 or b2 >= 1 or loc_start>b1:
                 raise ValueError("""Triangular distribution: Scale must be
-                    greater than zero; peak on interval [0,1]""")
+                    greater than zero; peak on interval [0,1], triangular start value must be smaller than end value""")
             else:
                 conv_params[:, i] = sp.stats.triang.ppf(
-                    params[:, i], c=b2, scale=b1, loc=0)
+                    params[:, i], c=b2, scale=b1-loc_start, loc=loc_start)
 
         elif dists[i] == 'unif':
             if b1 >= b2:


### PR DESCRIPTION
Hi, Please consider this improved triangular distribution syntax for Sobol Sensitivity Analysis, previously user was forced to start at 0 when specifying triangular distribution. Now we can start at any number >0.

Need to Update the Docs: First Parameter is now Triangular Distribution Start, Second Parameter is Triangular Distribution End, 3rd parameter is position of Peak.

![image](https://user-images.githubusercontent.com/72495991/167702899-e7488876-1976-4614-8543-a64f993b6926.png)
