### PR TITLE
Add Sobol' sampler from SciPy

### DIFF
--- a/src/SALib/sample/saltelli.py
+++ b/src/SALib/sample/saltelli.py
@@ -96,7 +96,8 @@ def sample(
     warnings.warn(
         "`salib.sample.saltelli` will be removed in SALib 1.5. Please use"
         " `salib.sample.sobol`",
-        category=DeprecationWarning, stacklevel=2
+        category=DeprecationWarning,
+        stacklevel=2,
     )
 
     # bit-shift test to check if `N` == 2**n

--- a/src/SALib/sample/saltelli.py
+++ b/src/SALib/sample/saltelli.py
@@ -28,6 +28,8 @@ def sample(
     These model inputs are intended to be used with
     :func:`SALib.analyze.sobol.analyze`.
 
+    .. deprecated:: 1.4.6
+
     Notes
     -----
     The initial points of the Sobol' sequence has some repetition (see Table 2
@@ -91,6 +93,12 @@ def sample(
            https://github.com/scipy/scipy/pull/10844#issuecomment-672186615
            https://github.com/scipy/scipy/pull/10844#issuecomment-673029539
     """
+    warnings.warn(
+        "`salib.sample.saltelli` will be removed in SALib 1.5. Please use"
+        " `salib.sample.sobol`",
+        category=DeprecationWarning, stacklevel=2
+    )
+
     # bit-shift test to check if `N` == 2**n
     if not ((N & (N - 1) == 0) and (N != 0 and N - 1 != 0)):
         msg = f"""

--- a/src/SALib/sample/sobol.py
+++ b/src/SALib/sample/sobol.py
@@ -5,9 +5,7 @@ import numpy as np
 from scipy.stats import qmc
 
 from . import common_args
-from ..util import (
-    scale_samples, read_param_file, compute_groups_matrix, _check_groups
-)
+from ..util import scale_samples, read_param_file, compute_groups_matrix, _check_groups
 
 
 def sample(
@@ -17,7 +15,7 @@ def sample(
     calc_second_order: bool = True,
     scramble: bool = True,
     skip_values: int = 0,
-    seed: Optional[Union[int, np.random.Generator]] = None
+    seed: Optional[Union[int, np.random.Generator]] = None,
 ):
     """
     Generates model inputs using Saltelli's extension of the Sobol' sequence.
@@ -98,16 +96,16 @@ def sample(
            The Second IMACS Seminar on Monte Carlo Methods 55, 271–280.
            https://doi.org/10.1016/S0378-4754(00)00270-6
     """
-    D = problem['num_vars']
+    D = problem["num_vars"]
     groups = _check_groups(problem)
 
     # Create base sequence - could be any type of sampling
-    qrng = qmc.Sobol(d=2*D, scramble=scramble, seed=seed)
+    qrng = qmc.Sobol(d=2 * D, scramble=scramble, seed=seed)
 
     # fast-forward logic
     if skip_values > 0:
         M = skip_values
-        if not ((M & (M-1) == 0) and (M != 0 and M-1 != 0)):
+        if not ((M & (M - 1) == 0) and (M != 0 and M - 1 != 0)):
             msg = f"""
             Convergence properties of the Sobol' sequence is only valid if
             `skip_values` ({M}) is a power of 2.
@@ -134,7 +132,7 @@ def sample(
     base_sequence = qrng.random(N)
 
     if not groups:
-        Dg = problem['num_vars']
+        Dg = problem["num_vars"]
     else:
         G, group_names = compute_groups_matrix(groups)
         Dg = len(set(group_names))
@@ -156,8 +154,7 @@ def sample(
         # Cross-sample elements of "B" into "A"
         for k in range(Dg):
             for j in range(D):
-                if (not groups and j == k) or \
-                   (groups and group_names[k] == groups[j]):
+                if (not groups and j == k) or (groups and group_names[k] == groups[j]):
                     saltelli_sequence[index, j] = base_sequence[i, j + D]
                 else:
                     saltelli_sequence[index, j] = base_sequence[i, j]
@@ -169,8 +166,9 @@ def sample(
         if calc_second_order:
             for k in range(Dg):
                 for j in range(D):
-                    if (not groups and j == k) or \
-                       (groups and group_names[k] == groups[j]):
+                    if (not groups and j == k) or (
+                        groups and group_names[k] == groups[j]
+                    ):
                         saltelli_sequence[index, j] = base_sequence[i, j]
                     else:
                         saltelli_sequence[index, j] = base_sequence[i, j + D]
@@ -199,25 +197,37 @@ def cli_parse(parser):
     Updated argparse object
     """
     parser.add_argument(
-        '--max-order', type=int, required=False, default=2, choices=[1, 2],
-        help='Maximum order of sensitivity indices to calculate'
+        "--max-order",
+        type=int,
+        required=False,
+        default=2,
+        choices=[1, 2],
+        help="Maximum order of sensitivity indices to calculate",
     )
 
     parser.add_argument(
-        '--scramble', type=int, required=False, default=True,
-        help='Use scrambled sequence'
+        "--scramble",
+        type=int,
+        required=False,
+        default=True,
+        help="Use scrambled sequence",
     )
 
     parser.add_argument(
-        '--skip-values', type=int, required=False, default=None,
-        help='Number of sample points to skip (default: next largest power of'
-             ' 2 from `samples`). Not recommended (use `scramble` instead).'
+        "--skip-values",
+        type=int,
+        required=False,
+        default=None,
+        help="Number of sample points to skip (default: next largest power of"
+        " 2 from `samples`). Not recommended (use `scramble` instead).",
     )
 
     # hacky way to remove an argument (seed option not relevant for Saltelli)
-    remove_opts = [x for x in parser._actions if x.dest == 'seed']
-    [parser._handle_conflict_resolve(None, [('--seed', x), ('-s', x)])
-     for x in remove_opts]
+    remove_opts = [x for x in parser._actions if x.dest == "seed"]
+    [
+        parser._handle_conflict_resolve(None, [("--seed", x), ("-s", x)])
+        for x in remove_opts
+    ]
 
     return parser
 
@@ -231,12 +241,17 @@ def cli_action(args):
     """
     problem = read_param_file(args.paramfile)
     param_values = sample(
-        problem, args.samples,
+        problem,
+        args.samples,
         calc_second_order=(args.max_order == 2),
-        scramble=args.scramble
+        scramble=args.scramble,
     )
-    np.savetxt(args.output, param_values, delimiter=args.delimiter,
-               fmt='%.' + str(args.precision) + 'e')
+    np.savetxt(
+        args.output,
+        param_values,
+        delimiter=args.delimiter,
+        fmt="%." + str(args.precision) + "e",
+    )
 
 
 if __name__ == "__main__":

--- a/src/SALib/sample/sobol.py
+++ b/src/SALib/sample/sobol.py
@@ -1,0 +1,187 @@
+from typing import Dict
+
+import numpy as np
+from scipy.stats import qmc
+
+from . import common_args
+from ..util import (scale_samples, read_param_file,
+                    compute_groups_matrix, _check_groups)
+
+
+def sample(
+    problem: Dict,
+    N: int,
+    *,
+    calc_second_order: bool = True,
+    scramble: bool = True
+):
+    """Generates model inputs using Saltelli's extension of the Sobol' sequence
+
+    The Sobol' sequence is a popular quasi-random low-discrepancy sequence used
+    to generate uniform samples of parameter space.
+
+    Returns a NumPy matrix containing the model inputs using Saltelli's
+    sampling scheme.
+    Saltelli's scheme extends the Sobol' sequence in a way to reduce
+    the error rates in the resulting sensitivity index calculations. If
+    `calc_second_order` is False, the resulting matrix has ``N * (D + 2)``
+    rows, where ``D`` is the number of parameters.
+    If `calc_second_order` is `True`, the resulting matrix has ``N * (2D + 2)``
+    rows.
+    These model inputs are intended to be used with
+    :func:`SALib.analyze.sobol.analyze`.
+
+    Notes
+    -----
+    The initial points of the Sobol' sequence has some repetition (see Table 2
+    in Campolongo [1]_), which can be avoided by setting the `skip_values`
+    parameter. Skipping values reportedly improves the uniformity of samples.
+    It has been shown that naively skipping values may reduce accuracy,
+    increasing the number of samples needed to achieve convergence
+    (see Owen [2]_).
+
+    Parameters
+    ----------
+    problem : dict
+        The problem definition
+    N : int
+        The number of samples to generate.
+        Ideally a power of 2 and <= `skip_values`.
+    calc_second_order : bool
+        Calculate second-order sensitivities (default True)
+    scramble : bool
+        Default is True.
+
+    References
+    ----------
+    .. [1] Campolongo, F., Saltelli, A., Cariboni, J., 2011.
+           From screening to quantitative sensitivity analysis.
+           A unified approach.
+           Computer Physics Communications 182, 978–988.
+           https://doi.org/10.1016/j.cpc.2010.12.039
+
+    .. [2] Owen, A. B., 2020.
+           On dropping the first Sobol' point.
+           arXiv:2008.08051 [cs, math, stat].
+           Available at: http://arxiv.org/abs/2008.08051
+           (Accessed: 20 April 2021).
+
+    .. [3] Saltelli, A., 2002.
+           Making best use of model evaluations to compute sensitivity indices.
+           Computer Physics Communications 145, 280–297.
+           https://doi.org/10.1016/S0010-4655(02)00280-1
+
+    .. [4] Sobol', I.M., 2001.
+           Global sensitivity indices for nonlinear mathematical models and
+           their Monte Carlo estimates.
+           Mathematics and Computers in Simulation,
+           The Second IMACS Seminar on Monte Carlo Methods 55, 271–280.
+           https://doi.org/10.1016/S0378-4754(00)00270-6
+    """
+    D = problem['num_vars']
+    groups = _check_groups(problem)
+
+    # Create base sequence - could be any type of sampling
+    qrng = qmc.Sobol(d=2*D, scramble=scramble)
+    base_sequence = qrng.random(N)
+
+    if not groups:
+        Dg = problem['num_vars']
+    else:
+        G, group_names = compute_groups_matrix(groups)
+        Dg = len(set(group_names))
+
+    if calc_second_order:
+        saltelli_sequence = np.zeros([(2 * Dg + 2) * N, D])
+    else:
+        saltelli_sequence = np.zeros([(Dg + 2) * N, D])
+    index = 0
+
+    for i in range(N):
+        # Copy matrix "A"
+        for j in range(D):
+            saltelli_sequence[index, j] = base_sequence[i, j]
+
+        index += 1
+
+        # Cross-sample elements of "B" into "A"
+        for k in range(Dg):
+            for j in range(D):
+                if (not groups and j == k) or \
+                   (groups and group_names[k] == groups[j]):
+                    saltelli_sequence[index, j] = base_sequence[i, j + D]
+                else:
+                    saltelli_sequence[index, j] = base_sequence[i, j]
+
+            index += 1
+
+        # Cross-sample elements of "A" into "B"
+        # Only needed if you're doing second-order indices (true by default)
+        if calc_second_order:
+            for k in range(Dg):
+                for j in range(D):
+                    if (not groups and j == k) or \
+                       (groups and group_names[k] == groups[j]):
+                        saltelli_sequence[index, j] = base_sequence[i, j]
+                    else:
+                        saltelli_sequence[index, j] = base_sequence[i, j + D]
+
+                index += 1
+
+        # Copy matrix "B"
+        for j in range(D):
+            saltelli_sequence[index, j] = base_sequence[i, j + D]
+
+        index += 1
+
+    saltelli_sequence = scale_samples(saltelli_sequence, problem)
+    return saltelli_sequence
+
+
+def cli_parse(parser):
+    """Add method specific options to CLI parser.
+
+    Parameters
+    ----------
+    parser : argparse object
+
+    Returns
+    ----------
+    Updated argparse object
+    """
+    parser.add_argument(
+        '--max-order', type=int, required=False, default=2, choices=[1, 2],
+        help='Maximum order of sensitivity indices to calculate'
+    )
+    parser.add_argument(
+        '--scramble', type=int, required=False, default=True,
+        help='Use scrambled sequence'
+    )
+
+    # hacky way to remove an argument (seed option not relevant for Saltelli)
+    remove_opts = [x for x in parser._actions if x.dest == 'seed']
+    [parser._handle_conflict_resolve(None, [('--seed', x), ('-s', x)])
+     for x in remove_opts]
+
+    return parser
+
+
+def cli_action(args):
+    """Run sampling method
+
+    Parameters
+    ----------
+    args : argparse namespace
+    """
+    problem = read_param_file(args.paramfile)
+    param_values = sample(
+        problem, args.samples,
+        calc_second_order=(args.max_order == 2),
+        scramble=args.scramble
+    )
+    np.savetxt(args.output, param_values, delimiter=args.delimiter,
+               fmt='%.' + str(args.precision) + 'e')
+
+
+if __name__ == "__main__":
+    common_args.run_cli(cli_parse, cli_action)

--- a/src/SALib/sample/sobol.py
+++ b/src/SALib/sample/sobol.py
@@ -63,6 +63,7 @@ def sample(
     skip_values : int, optional
         Number of points in Sobol' sequence to skip, ideally a value of base 2.
         It's recommended not to change this value and use `scramble` instead.
+        `scramble` and `skip_values` can be used together.
         Default is 0.
     seed : {None, int, `numpy.random.Generator`}, optional
         If `seed` is None the `numpy.random.Generator` generator is used.
@@ -142,6 +143,7 @@ def sample(
         saltelli_sequence = np.zeros([(2 * Dg + 2) * N, D])
     else:
         saltelli_sequence = np.zeros([(Dg + 2) * N, D])
+
     index = 0
 
     for i in range(N):
@@ -205,10 +207,11 @@ def cli_parse(parser):
         '--scramble', type=int, required=False, default=True,
         help='Use scrambled sequence'
     )
-    
+
     parser.add_argument(
         '--skip-values', type=int, required=False, default=None,
-        help='Number of sample points to skip (default: next largest power of 2 from `samples`). Not recommended (use `scramble` instead).'
+        help='Number of sample points to skip (default: next largest power of'
+             ' 2 from `samples`). Not recommended (use `scramble` instead).'
     )
 
     # hacky way to remove an argument (seed option not relevant for Saltelli)

--- a/src/SALib/sample/sobol.py
+++ b/src/SALib/sample/sobol.py
@@ -200,9 +200,15 @@ def cli_parse(parser):
         '--max-order', type=int, required=False, default=2, choices=[1, 2],
         help='Maximum order of sensitivity indices to calculate'
     )
+
     parser.add_argument(
         '--scramble', type=int, required=False, default=True,
         help='Use scrambled sequence'
+    )
+    
+    parser.add_argument(
+        '--skip-values', type=int, required=False, default=None,
+        help='Number of sample points to skip (default: next largest power of 2 from `samples`). Not recommended (use `scramble` instead).'
     )
 
     # hacky way to remove an argument (seed option not relevant for Saltelli)

--- a/src/SALib/sample/sobol.py
+++ b/src/SALib/sample/sobol.py
@@ -14,6 +14,7 @@ def sample(
     *,
     calc_second_order: bool = True,
     scramble: bool = True
+    seed: Optional[Union[int, np.random.Generator]] = None
 ):
     """Generates model inputs using Saltelli's extension of the Sobol' sequence
 
@@ -51,6 +52,12 @@ def sample(
         Calculate second-order sensitivities (default True)
     scramble : bool
         Default is True.
+    seed : {None, int, `numpy.random.Generator`}, optional
+        If `seed` is None the `numpy.random.Generator` generator is used.
+        If `seed` is an int, a new ``Generator`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` instance then that instance is
+        used. Default is None.
 
     References
     ----------
@@ -82,7 +89,7 @@ def sample(
     groups = _check_groups(problem)
 
     # Create base sequence - could be any type of sampling
-    qrng = qmc.Sobol(d=2*D, scramble=scramble)
+    qrng = qmc.Sobol(d=2*D, scramble=scramble, seed=seed)
     base_sequence = qrng.random(N)
 
     if not groups:


### PR DESCRIPTION
Closes #486, closes #450 and should close #478 as if the method does work better (which I am not convinced yet from my tests) should go in SciPy directly.

Following discussions in #486, this adds Sobol' sampler as a new sampler and deprecate `salib.sample.saltelli`.

Note that SciPy also has LHS (and Halton that can be used otherwise).

This needs SciPy to 1.7 and doing so I updated NumPy and Python minimal versions following NEP29.

This is a draft as I need some guidance on how to proceed next. E.g. I removed the skipping as we can scramble and should have better properties doing so.

cc @ConnectedSystems 