### PR TITLE
Make Pathos optional

### DIFF
--- a/examples/Problem/problem_spec.py
+++ b/examples/Problem/problem_spec.py
@@ -78,6 +78,9 @@ if __name__ == "__main__":
     print(sp)
 
     # Distributed example
+    # This example requires an additional dependency (Pathos) to be installed
+    # `pip install pathos` or `conda install pathos -c conda-forge`
+
     # Specify itself as servers as an example
     servers = ("localhost:55774", "localhost:55775", "localhost:55776")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,16 @@ dependencies = [
   "scipy>=1.7.3",
   "matplotlib>=3.2.2",
   "pandas>=1.1.2",
-  "pathos>=0.2.5",
+  "multiprocess",
 ]
 
 [project.optional-dependencies]
+distributed = [
+    "pathos>=0.2.5",
+]
+
 test = [
+    "SALib[distributed]",
     "pytest",
     "pytest-cov",
 ]
@@ -51,6 +56,7 @@ doc = [
 ]
 
 dev = [
+    "SALib[distributed]",
     "SALib[test]",
     "SALib[doc]",
     "pre-commit",

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -21,6 +21,7 @@ except ImportError:
 
 try:
     from pathos.pp import ParallelPythonPool as pp_Pool
+
     pathos_available = True
 except ImportError:
     pathos_available = False

--- a/src/SALib/util/problem.py
+++ b/src/SALib/util/problem.py
@@ -1,11 +1,9 @@
 import warnings
 import importlib
 from types import MethodType
-
-from multiprocess import Pool, cpu_count
-from pathos.pp import ParallelPythonPool as pp_Pool
 from functools import partial, wraps
 
+from multiprocess import Pool, cpu_count
 import numpy as np
 
 import SALib.sample as samplers
@@ -20,6 +18,13 @@ try:
     from p_tqdm import p_imap
 except ImportError:
     ptqdm_available = False
+
+try:
+    from pathos.pp import ParallelPythonPool as pp_Pool
+    pathos_available = True
+except ImportError:
+    pathos_available = False
+
 
 __all__ = ["ProblemSpec"]
 
@@ -262,6 +267,13 @@ class ProblemSpec(dict):
         ----------
         self : ProblemSpec object
         """
+        if not pathos_available:
+            raise RuntimeError(
+                "Pathos is required to run in distributed mode. Please install"
+                " with `pip install pathos` or"
+                " `conda install pathos -c conda-forge`"
+            )
+
         if verbose:
             from pathos.parallel import stats
 


### PR DESCRIPTION
Closes #521

This removes the dependency to Pathos to make it optional.

We could also do something similar for `multiprocess` (which is pulled by `Pathos` at the moment and used for parallel execution.). In that case, it should be fairly easy to write compatible code that would use `multiprocess` if installed and fallback to `multiprocessing` if not.

I am not sure about how the packaging is handled, so I did not update for now the requirements files (and I would suggest moving to something simpler like `flit` or `hatch` which is now the recommendation for pure Python packages (see https://packaging.python.org/en/latest/tutorials/packaging-projects/), I can do the lifting here if wanted).