### PR TITLE
Allow seed as CLI option

### DIFF
--- a/src/SALib/sample/sobol.py
+++ b/src/SALib/sample/sobol.py
@@ -222,13 +222,6 @@ def cli_parse(parser):
         " 2 from `samples`). Not recommended (use `scramble` instead).",
     )
 
-    # hacky way to remove an argument (seed option not relevant for Saltelli)
-    remove_opts = [x for x in parser._actions if x.dest == "seed"]
-    [
-        parser._handle_conflict_resolve(None, [("--seed", x), ("-s", x)])
-        for x in remove_opts
-    ]
-
     return parser
 
 


### PR DESCRIPTION
Need to allow setting a seed value via the CLI.
This was disabled for the Saltelli sampling method as it did not use a seed, but is necessary to make scrambled sequences deterministic.

Quick and easy change, missed this in the first PR.