### PR TITLE
Triang dist bounds fix

### DIFF
--- a/src/SALib/util/__init__.py
+++ b/src/SALib/util/__init__.py
@@ -187,7 +187,7 @@ def _nonuniform_scale_samples(params, bounds, dists):
                 )
 
             # checking for correct parameters
-            if b1 <= 0 or b2 <= 0 or b2 >= 1 or loc_start > b1:
+            if b1 < 0 or b2 < 0 or b2 >= 1 or loc_start > b1:
                 raise ValueError(
                     """Triangular distribution: Scale must be
                     greater than zero; peak on interval [0,1], triangular

--- a/src/SALib/util/__init__.py
+++ b/src/SALib/util/__init__.py
@@ -165,7 +165,7 @@ def _nonuniform_scale_samples(params, bounds, dists):
             if len(b[i]) == 3:
                 loc_start = b[i][0]  # loc start
                 b1 = b[i][1]  # triangular distribution end
-                b2 = b[i][2]  # 0-1 aka c
+                b2 = b[i][2]  # 0-1 aka c (the peak)
             elif len(b[i]) == 2:
                 msg = (
                     "Two-value format for triangular distributions detected.\n"
@@ -189,7 +189,7 @@ def _nonuniform_scale_samples(params, bounds, dists):
             # checking for correct parameters
             if b1 < 0 or b2 < 0 or b2 >= 1 or loc_start > b1:
                 raise ValueError(
-                    """Triangular distribution: Scale must be
+                    """Triangular distribution bound error: Scale must be
                     greater than zero; peak on interval [0,1], triangular
                     start value must be smaller than end value"""
                 )


### PR DESCRIPTION
Allow specified bounds to be equal to zero when defining triangular distributions