### PR TITLE
Lower tolerance in test_parallel_single_output test

### DIFF
--- a/tests/test_problem_spec.py
+++ b/tests/test_problem_spec.py
@@ -166,10 +166,14 @@ def test_parallel_multi_output():
     )
 
     assert (
-        np.testing.assert_equal(sp.results, psp.results) is None
+        np.testing.assert_allclose(
+            sp.results, psp.results, atol=1e-10
+        ) is None
     ), "Model results not equal!"
     assert (
-        np.testing.assert_equal(sp.analysis, psp.analysis) is None
+        np.testing.assert_allclose(
+            sp.analysis, psp.analysis, atol=1e-10
+        ) is None
     ), "Analysis results not equal!"
 
 


### PR DESCRIPTION
As seen in CI here: https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315

```
FAILED tests/test_problem_spec.py::test_parallel_single_output - AssertionError: 
[383](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:384)
Arrays are not equal
[384](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:385)

[385](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:386)
Mismatched elements: 82 / 2048 (4%)
[386](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:387)
Max absolute difference: 3.55271368e-15
[387](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:388)
Max relative difference: 3.64569322e-15
[388](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:389)
 x: array([-0.041478, -1.108749,  6.722943, ...,  3.420459,  5.26721 ,
[389](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:390)
        7.8529  ])
[390](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:391)
 y: array([-0.041478, -1.108749,  6.722943, ...,  3.420459,  5.26721 ,
[391](https://github.com/SALib/SALib/actions/runs/3864699280/jobs/6587685315#step:9:392)
        7.8529  ])
```

Tolerance could be relaxed to make this pass.