### PR TITLE
hdmr maxorder=1 fix

### DIFF
--- a/src/SALib/analyze/hdmr.py
+++ b/src/SALib/analyze/hdmr.py
@@ -744,13 +744,13 @@ def _finalize(problem, SA, Em, d, alpha, maxorder, RT, Y_em, bootstrap_idx, X, Y
     # Fill Expansion Terms
     ct = 0
     p_names = problem["names"]
-    
+
     if maxorder == 2:
         p_c2 = Em["c2"]
     elif maxorder == 3:
         p_c2 = Em["c2"]
-        p_c3 = Em['c3']
-        
+        p_c3 = Em["c3"]
+
     for i in range(Em["n1"]):
         Si["Term"][ct] = p_names[i]
         ct += 1
@@ -839,7 +839,7 @@ def emulate(self, X, Y=None):
     m1 = m + 3
     n1, n2, n3 = d, 0, 0
     maxorder = 1
-    
+
     if C2.shape[0] != 1:
         maxorder = 2
         m2 = C2.shape[0]

--- a/src/SALib/analyze/hdmr.py
+++ b/src/SALib/analyze/hdmr.py
@@ -744,8 +744,13 @@ def _finalize(problem, SA, Em, d, alpha, maxorder, RT, Y_em, bootstrap_idx, X, Y
     # Fill Expansion Terms
     ct = 0
     p_names = problem["names"]
-    p_c2 = Em["c2"]
-    # p_c3 = Em['c3']
+    
+    if maxorder == 2:
+        p_c2 = Em["c2"]
+    elif maxorder == 3:
+        p_c2 = Em["c2"]
+        p_c3 = Em['c3']
+        
     for i in range(Em["n1"]):
         Si["Term"][ct] = p_names[i]
         ct += 1
@@ -833,6 +838,8 @@ def emulate(self, X, Y=None):
     m = C1.shape[0] - 3
     m1 = m + 3
     n1, n2, n3 = d, 0, 0
+    maxorder = 1
+    
     if C2.shape[0] != 1:
         maxorder = 2
         m2 = C2.shape[0]

--- a/src/SALib/analyze/hdmr.py
+++ b/src/SALib/analyze/hdmr.py
@@ -745,11 +745,10 @@ def _finalize(problem, SA, Em, d, alpha, maxorder, RT, Y_em, bootstrap_idx, X, Y
     ct = 0
     p_names = problem["names"]
 
-    if maxorder == 2:
+    if maxorder > 1:
         p_c2 = Em["c2"]
-    elif maxorder == 3:
-        p_c2 = Em["c2"]
-        p_c3 = Em["c3"]
+        if maxorder == 3:
+            p_c3 = Em["c3"]
 
     for i in range(Em["n1"]):
         Si["Term"][ct] = p_names[i]
@@ -761,7 +760,7 @@ def _finalize(problem, SA, Em, d, alpha, maxorder, RT, Y_em, bootstrap_idx, X, Y
 
     for i in range(Em["n3"]):
         Si["Term"][ct] = "/".join(
-            [p_names[Em["c3"][i, 0]], p_names[Em["c3"][i, 1]], p_names[Em["c3"][i, 2]]]
+            [p_names[p_c3[i, 0]], p_names[p_c3[i, 1]], p_names[p_c3[i, 2]]]
         )
         ct += 1
 

--- a/tests/test_problem_spec.py
+++ b/tests/test_problem_spec.py
@@ -122,10 +122,14 @@ def test_parallel_single_output():
     )
 
     assert (
-        np.testing.assert_equal(sp.results, psp.results) is None
+        np.testing.assert_allclose(sp.results, psp.results, rtol=1e-3, atol=1e-3)
+        is None
     ), "Model results not equal!"
     assert (
-        np.testing.assert_equal(sp.analysis, psp.analysis) is None
+        np.testing.assert_assert_allcloseequal(
+            sp.analysis, psp.analysis, rtol=1e-3, atol=1e-3
+        )
+        is None
     ), "Analysis results not equal!"
 
 


### PR DESCRIPTION
**hdmr** method was throwing a `keyerror` for `c2` if `maxorder = 1`

`keyerror` and corresponding `referencing before assignment` fixed.