### PR TITLE
Add discrepancy analysis

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -77,7 +77,13 @@ High-Dimensional Model Representation
    :noindex:
 
 Regional Sensitivity Analysis
--------------------------------------
+-----------------------------
 
 .. autofunction:: SALib.analyze.rsa.analyze
+   :noindex:
+
+Discrepancy Sensitivity Indices
+-------------------------------
+
+.. autofunction:: SALib.analyze.discrepancy.analyze
    :noindex:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,6 @@ Other Info
 .. toctree::
     :maxdepth: 2
 
-   License <license>
-   Authors <authors>
-   Projects that use SALib <citations>
+    License <license>
+    Authors <authors>
+    Projects that use SALib <citations>

--- a/src/SALib/analyze/discrepancy.py
+++ b/src/SALib/analyze/discrepancy.py
@@ -39,6 +39,22 @@ def analyze(
     Compatible with:
         all samplers
 
+    Based on 2D sub projections of ``[Xi,Y]``, the discrepancy of each sample
+    is calculated which gives a value for all ``Xi``. This information is used
+    as a sensitivity indice.
+
+    This measure is very fast and is visually explainable. Considering two
+    variables ``X1`` and ``X2``, ``X1`` is more influential than ``X2`` when
+    the scatterplot of ``X1`` against ``Y`` displays a more discernible shape
+    than the scatterplot of ``X2`` against ``Y``.
+
+    For the method to work properly, the input parameter space need to be
+    uniformely covered as the quality of the measure depends on the value of
+    the discrepancy. Taking a 2D sub projection, if the distribution of sample
+    along ``Xi`` is not uniform, it will have an impact on the discrepancy,
+    the value will increase, i.e. the importance of this parameter would be
+    inflated.
+
     References
     ----------
     1. A. Puy, P.T. Roy and A. Saltelli. 2023. Discrepancy measures for

--- a/src/SALib/analyze/discrepancy.py
+++ b/src/SALib/analyze/discrepancy.py
@@ -21,18 +21,16 @@ def analyze(
     ----------
     problem : dict
         The problem definition
-    X : numpy.ndarray
-        A NumPy array containing the model inputs
-    Y : numpy.ndarray
-        A NumPy array containing the model outputs
-    method : str
-        Type of discrepancy, can be 'CD', 'WD', 'MD' or 'L2-star'.
-        Refer to `scipy.stats.qmc.discrepancy` for more details. Default is WD.
-    print_to_console : bool
+    X, Y : numpy.ndarray
+        An array of model inputs and outputs.
+    method : {"WD", "CD", "MD", "L2-star"}
+        Type of discrepancy. Refer to `scipy.stats.qmc.discrepancy` for more
+        details. Default is "WD".
+    print_to_console : bool, optional
         Print results directly to console (default False)
-    seed : int
+    seed : int, optional
         Seed value to ensure deterministic results
-        Unused, but defined to maintain compatibility.
+        Unused, but defined to maintain compatibility with other functions.
 
     Notes
     -----
@@ -41,15 +39,15 @@ def analyze(
 
     Based on 2D sub projections of ``[Xi,Y]``, the discrepancy of each sample
     is calculated which gives a value for all ``Xi``. This information is used
-    as a sensitivity indice.
+    as a measure of sensitivity.
 
-    This measure is very fast and is visually explainable. Considering two
-    variables ``X1`` and ``X2``, ``X1`` is more influential than ``X2`` when
-    the scatterplot of ``X1`` against ``Y`` displays a more discernible shape
-    than the scatterplot of ``X2`` against ``Y``.
+    Discrepancy analysis is very fast and is visually explainable. Considering
+    two variables ``X1`` and ``X2``, ``X1`` is more influential than ``X2``
+    when the scatterplot of ``X1`` against ``Y`` displays a more discernible
+    shape than the scatterplot of ``X2`` against ``Y``.
 
     For the method to work properly, the input parameter space need to be
-    uniformely covered as the quality of the measure depends on the value of
+    uniformly covered as the quality of the measure depends on the value of
     the discrepancy. Taking a 2D sub projection, if the distribution of sample
     along ``Xi`` is not uniform, it will have an impact on the discrepancy,
     the value will increase, i.e. the importance of this parameter would be
@@ -84,7 +82,6 @@ def analyze(
         >>> X = latin.sample(problem, 1000)
         >>> Y = Ishigami.evaluate(X)
         >>> Si = discrepancy.analyze(problem, X, Y, print_to_console=True)
-
     """
     D = problem["num_vars"]
     groups = _check_groups(problem)

--- a/src/SALib/analyze/discrepancy.py
+++ b/src/SALib/analyze/discrepancy.py
@@ -1,0 +1,124 @@
+from typing import Dict
+
+import numpy as np
+from scipy.stats import qmc
+
+from SALib.analyze import common_args
+from SALib.util import read_param_file, ResultDict
+
+
+def analyze(
+    problem: Dict,
+    X: np.ndarray,
+    Y: np.ndarray,
+    method: str = "WD",
+    print_to_console: bool = False,
+    seed: int = None,
+):
+    """Discrepancy indices.
+
+    Parameters
+    ----------
+    problem : dict
+        The problem definition
+    X : numpy.ndarray
+        A NumPy array containing the model inputs
+    Y : numpy.ndarray
+        A NumPy array containing the model outputs
+    method : str
+        Type of discrepancy, can be 'CD', 'WD', 'MD' or 'L2-star'.
+        Refer to `scipy.stats.qmc.discrepancy` for more details. Default is WD.
+    print_to_console : bool
+        Print results directly to console (default False)
+    seed : int
+        Seed value to ensure deterministic results
+        Unused, but defined to maintain compatibility.
+
+    Notes
+    -----
+    Compatible with:
+        all samplers
+
+    References
+    ----------
+    1. A. Puy, P.T. Roy and A. Saltelli. 2023. Discrepancy measures for
+    sensitivity analysis. https://arxiv.org/abs/2206.13470
+
+    2. A. Saltelli, M. Ratto, T. Andres, F. Campolongo, J. Cariboni, D. Gatelli,
+    M. Saisana, and S. Tarantola. 2008.
+    Global Sensitivity Analysis: The Primer.
+    Wiley, West Sussex, U.K.
+    https://dx.doi.org/10.1002/9780470725184
+    Accessible at:
+    http://www.andreasaltelli.eu/file/repository/Primer_Corrected_2022.pdf
+
+    Examples
+    --------
+
+        >>> import numpy as np
+        >>> from SALib.sample import latin
+        >>> from SALib.analyze import discrepancy
+        >>> from SALib.test_functions import Ishigami
+
+        >>> problem = {
+        ...   'num_vars': 3,
+        ...   'names': ['x1', 'x2', 'x3'],
+        ...   'bounds': [[-np.pi, np.pi]]*3
+        ... }
+        >>> X = latin.sample(problem, 1000)
+        >>> Y = Ishigami.evaluate(X)
+        >>> Si = discrepancy.analyze(problem, X, Y, print_to_console=True)
+
+    """
+    D = problem["num_vars"]
+    Y = Y.reshape(-1, 1)
+
+    bounds = np.asarray(problem["bounds"]).T
+    X = qmc.scale(sample=X, l_bounds=bounds[0], u_bounds=bounds[1], reverse=True)
+
+    Y = qmc.scale(sample=Y, l_bounds=np.min(Y), u_bounds=np.max(Y), reverse=True)
+
+    s_discrepancy = [
+        qmc.discrepancy(np.concatenate([X[:, i, None], Y], axis=1), method=method)
+        for i in range(D)
+    ]
+
+    s_discrepancy = s_discrepancy / np.sum(s_discrepancy)
+
+    keys = ("s_discrepancy",)
+    Si = ResultDict((k, np.zeros(D)) for k in keys)
+    Si["names"] = problem["names"]
+
+    Si["s_discrepancy"] = s_discrepancy
+
+    if print_to_console:
+        print(Si.to_df())
+
+    return Si
+
+
+def cli_parse(parser):
+    parser.add_argument(
+        "-X", "--model-input-file", type=str, required=True, help="Model input file"
+    )
+
+    return parser
+
+
+def cli_action(args):
+    problem = read_param_file(args.paramfile)
+    X = np.loadtxt(args.model_input_file, delimiter=args.delimiter)
+    Y = np.loadtxt(
+        args.model_output_file, delimiter=args.delimiter, usecols=(args.column,)
+    )
+    analyze(
+        problem,
+        X,
+        Y,
+        print_to_console=True,
+        seed=args.seed,
+    )
+
+
+if __name__ == "__main__":
+    common_args.run_cli(cli_parse, cli_action)

--- a/src/SALib/analyze/morris.py
+++ b/src/SALib/analyze/morris.py
@@ -53,10 +53,10 @@ def analyze(
 
     Examples
     --------
-        >>> X = morris.sample(problem, 1000, num_levels=4)
-        >>> Y = Ishigami.evaluate(X)
-        >>> Si = morris.analyze(problem, X, Y, conf_level=0.95,
-        >>>                     print_to_console=True, num_levels=4)
+    >>> X = morris.sample(problem, 1000, num_levels=4)
+    >>> Y = Ishigami.evaluate(X)
+    >>> Si = morris.analyze(problem, X, Y, conf_level=0.95,
+    >>>                     print_to_console=True, num_levels=4)
 
 
     Parameters

--- a/src/SALib/analyze/sobol.py
+++ b/src/SALib/analyze/sobol.py
@@ -49,9 +49,9 @@ def analyze(
 
     Examples
     --------
-        >>> X = saltelli.sample(problem, 512)
-        >>> Y = Ishigami.evaluate(X)
-        >>> Si = sobol.analyze(problem, Y, print_to_console=True)
+    >>> X = saltelli.sample(problem, 512)
+    >>> Y = Ishigami.evaluate(X)
+    >>> Si = sobol.analyze(problem, Y, print_to_console=True)
 
 
     Parameters
@@ -359,10 +359,10 @@ def Si_to_pandas_dict(S_dict):
 
     Examples
     --------
-        >>> X = saltelli.sample(problem, 512)
-        >>> Y = Ishigami.evaluate(X)
-        >>> Si = sobol.analyze(problem, Y, print_to_console=True)
-        >>> T_Si, first_Si, (idx, second_Si) = sobol.Si_to_pandas_dict(Si, problem)
+    >>> X = saltelli.sample(problem, 512)
+    >>> Y = Ishigami.evaluate(X)
+    >>> Si = sobol.analyze(problem, Y, print_to_console=True)
+    >>> T_Si, first_Si, (idx, second_Si) = sobol.Si_to_pandas_dict(Si, problem)
 
 
     Parameters
@@ -418,8 +418,8 @@ def to_df(self):
     -------
     List : of Pandas DataFrames in order of Total, First, Second
 
-    Example
-    -------
+    Examples
+    --------
     >>> Si = sobol.analyze(problem, Y, print_to_console=True)
     >>> total_Si, first_Si, second_Si = Si.to_df()
     """

--- a/src/SALib/sample/morris/local.py
+++ b/src/SALib/sample/morris/local.py
@@ -165,8 +165,8 @@ class LocalOptimisation(Strategy):
         indices : tuple
         distance_matrix : numpy.ndarray (M,M)
 
-        Example
-        -------
+        Examples
+        --------
         >>> add_indices((1,2), numpy.array((5,5)))
         [(1, 2, 3), (1, 2, 4), (1, 2, 5)]
 

--- a/src/SALib/test_functions/lake_problem.py
+++ b/src/SALib/test_functions/lake_problem.py
@@ -73,7 +73,7 @@ def evaluate_lake(values: np.ndarray, seed=101) -> np.ndarray:
     ----------
     .. [1] Hadka, D., Herman, J., Reed, P., Keller, K., (2015).
            "An open source framework for many-objective robust decision
-                making."
+           making."
            Environmental Modelling & Software 74, 114–129.
            doi:10.1016/j.envsoft.2015.07.014
 
@@ -86,15 +86,15 @@ def evaluate_lake(values: np.ndarray, seed=101) -> np.ndarray:
     Parameters
     ----------
     values : np.ndarray,
-             model inputs in the (column) order of
-             a, q, b, mean, stdev
+        model inputs in the (column) order of
+        a, q, b, mean, stdev
 
-             where
-             * `a` is rate of anthropogenic pollution
-             * `q` is exponent controlling recycling rate
-             * `b` is decay rate for phosphorus
-             * `mean` and
-             * `stdev` set the log normal distribution of `eps`, see [2]
+        where
+        * `a` is rate of anthropogenic pollution
+        * `q` is exponent controlling recycling rate
+        * `b` is decay rate for phosphorus
+        * `mean` and
+        * `stdev` set the log normal distribution of `eps`, see [2]
 
     Returns
     -------

--- a/tests/test_discrepancy.py
+++ b/tests/test_discrepancy.py
@@ -1,0 +1,19 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from SALib.sample import latin
+from SALib.analyze import discrepancy
+from SALib.test_functions import Ishigami
+
+
+def test_discrepancy():
+    problem = {
+        "num_vars": 3,
+        "names": ["x1", "x2", "x3"],
+        "bounds": [[-np.pi, np.pi]] * 3,
+    }
+    X = latin.sample(problem, 1_000)
+    Y = Ishigami.evaluate(X)
+    Si = discrepancy.analyze(problem, X, Y)
+
+    assert_allclose(Si["s_discrepancy"], [0.33, 0.33, 0.33], atol=5e-3)


### PR DESCRIPTION
Add `SALib.analyze.discrepancy` which is the method described in https://arxiv.org/abs/2206.13470

Based on 2D sub projections of [Xi,Y], the discrepancy of each samples is calculated which gives a value for all Xi. This can be used as a sensitivity indice.

Opening this in draft to get early feedbacks on how to proceed next. It's mainly missing tests and doc, but the feature itself should already work.

cc @arnaldpuy