### PR TITLE
legend subscript fix for num_vars>10

### DIFF
--- a/src/SALib/plotting/hdmr.py
+++ b/src/SALib/plotting/hdmr.py
@@ -80,7 +80,7 @@ def plot(Si):
         ax.plot(X[last_bootstrap, i], Y[last_bootstrap], "r.")
         ax.plot(X[last_bootstrap, i], np.mean(Em["f0"]) + Y_em[:, i], "k.")
         ax.legend(
-            [r"$\widetilde{Y}$", "$f_" + str(i + 1) + "$"],
+            [r"$\widetilde{Y}$", "$f_{" + str(i + 1) + "}$"],
             loc="upper left",
             bbox_to_anchor=(1.04, 1.0),
         )


### PR DESCRIPTION
Legend subscripts were not correctly displayed if `num_vars>10`. This should fix that.

For testing, modify line 14 in _**examples\hdmr\hdmr.py**_ as:
`problem = {"num_vars": 11, "names": ["x1", "x2", "x3","x4","x5","x6","x7","x8","x9","x10","x11"], "bounds": [[-np.pi, np.pi]] * 11}` 