### PR TITLE
Switch to Cramer-von Mises test for RSA, remove normalization (fix #587)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Included methods
 
 * PAWN (`Pianosi and Wagener 2018 <https://dx.doi.org/10.1016/j.envsoft.2018.07.019>`__, `Pianosi and Wagener 2015 <https://doi.org/10.1016/j.envsoft.2015.01.004>`__)
 
-* Regional Sensitivity Analysis (based on `Saltelli et al. 2008 <https://dx.doi.org/10.1002/9780470725184>`__, `Pianosi et al., 2016 <https://dx.doi.org/10.1016/j.envsoft.2016.02.008>`__)
+* Regional Sensitivity Analysis (based on `Hornberger and Spear, 1981 <https://www.osti.gov/biblio/6396608-approach-preliminary-analysis-environmental-systems>`__, `Saltelli et al. 2008 <https://dx.doi.org/10.1002/9780470725184>`__, `Pianosi et al., 2016 <https://dx.doi.org/10.1016/j.envsoft.2016.02.008>`__)
 
 
 **Contributing:** see `here <CONTRIBUTING.md>`__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ Supported Methods
 * PAWN
   (`Pianosi and Wagener 2018 <https://dx.doi.org/10.1016/j.envsoft.2018.07.019>`__, `Pianosi and Wagener 2015 <https://doi.org/10.1016/j.envsoft.2015.01.004>`__)
 * Regional Sensitivity Analysis
-  (based on `Saltelli et al. 2008 <https://dx.doi.org/10.1002/9780470725184>`__, `Pianosi et al., 2016 <https://dx.doi.org/10.1016/j.envsoft.2016.02.008>`__)
+  (based on `Hornberger and Spear, 1981 <https://www.osti.gov/biblio/6396608-approach-preliminary-analysis-environmental-systems>`__, `Saltelli et al. 2008 <https://dx.doi.org/10.1002/9780470725184>`__, `Pianosi et al., 2016 <https://dx.doi.org/10.1016/j.envsoft.2016.02.008>`__)
 
 
 Getting Started

--- a/src/SALib/analyze/rsa.py
+++ b/src/SALib/analyze/rsa.py
@@ -45,7 +45,7 @@ def analyze(
 
     The two-sample Cramér-von Mises (CvM) test is used to compare distributions.
     Results of the analysis indicate sensitivity across factor/output space. As the
-    Cramér-von Mises criterion ranges from 0 to :math:`\\infinity`, a value of zero will
+    Cramér-von Mises criterion ranges from 0 to :math:`\\infty`, a value of zero will
     indicates the two distributions being compared are identical, with larger values
     indicating greater differences.
 
@@ -87,20 +87,25 @@ def analyze(
 
     References
     ----------
-    1. Pianosi, F., K. Beven, J. Freer, J. W. Hall, J. Rougier, D. B. Stephenson, and
-    T. Wagener. 2016.
-    Sensitivity analysis of environmental models:
-    A systematic review with practical workflow.
-    Environmental Modelling & Software 79:214-232.
-    https://dx.doi.org/10.1016/j.envsoft.2016.02.008
+    1. Hornberger, G. M., and R. C. Spear. 1981.
+        Approach to the preliminary analysis of environmental systems.
+        Journal of Environmental Management 12:1.
+        https://www.osti.gov/biblio/6396608-approach-preliminary-analysis-environmental-systems
 
-    2. Saltelli, A., M. Ratto, T. Andres, F. Campolongo, J. Cariboni, D. Gatelli,
-    M. Saisana, and S. Tarantola. 2008.
-    Global Sensitivity Analysis: The Primer.
-    Wiley, West Sussex, U.K.
-    https://dx.doi.org/10.1002/9780470725184
-    Accessible at:
-    http://www.andreasaltelli.eu/file/repository/Primer_Corrected_2022.pdf
+    2. Pianosi, F., K. Beven, J. Freer, J. W. Hall, J. Rougier, D. B. Stephenson, and
+        T. Wagener. 2016.
+        Sensitivity analysis of environmental models:
+        A systematic review with practical workflow.
+        Environmental Modelling & Software 79:214-232.
+        https://dx.doi.org/10.1016/j.envsoft.2016.02.008
+
+    3. Saltelli, A., M. Ratto, T. Andres, F. Campolongo, J. Cariboni, D. Gatelli,
+        M. Saisana, and S. Tarantola. 2008.
+        Global Sensitivity Analysis: The Primer.
+        Wiley, West Sussex, U.K.
+        https://dx.doi.org/10.1002/9780470725184
+        Accessible at:
+        http://www.andreasaltelli.eu/file/repository/Primer_Corrected_2022.pdf
     """
     groups = _check_groups(problem)
     if not groups:


### PR DESCRIPTION
Remove normalization in Regional Sensitivity Analysis (as discussed in https://github.com/SALib/SALib/issues/587) and replace the Anderson-Darling test in favor of the Cramér-von Mises (CvM) test.

Normalization has the effect of making reported values sensitive to the maximum influence, making small values appear close to 0. Although these are smaller than the maximum, they could still indicate large differences in the distributions.

The CvM test is used as it reports values between 0 and $+\infty$, avoiding negative values in cases where users would like to simply max-normalize.


