### PR TITLE
Remove a useless shebang line

### DIFF
--- a/src/SALib/analyze/rbd_fast.py
+++ b/src/SALib/analyze/rbd_fast.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding=utf8
 
 import numpy as np


### PR DESCRIPTION
While the file is script-like (has “`if __name__ == __main__:`” or otherwise has interesting side effects), the executable bit is not set in its filesystem permissions,so the shebang line is not useful. It can still be executed with “`python -m SALib.analyze.rbd_fast`”.