### PR TITLE
Remove deprecated saltelli sample from start doc

### DIFF
--- a/docs/user_guide/getting-started.rst
+++ b/docs/user_guide/getting-started.rst
@@ -59,8 +59,8 @@ and copy/paste the code below.
 
 .. code:: python
 
-    from SALib.sample import saltelli
-    from SALib.analyze import sobol
+    from SALib.analyze.sobol import analyze
+    from SALib.sample.sobol import sample
     from SALib.test_functions import Ishigami
     import numpy as np
 
@@ -74,13 +74,13 @@ and copy/paste the code below.
     }
 
     # Generate samples
-    param_values = saltelli.sample(problem, 1024)
+    param_values = sample(problem, 1024)
 
     # Run model (example)
     Y = Ishigami.evaluate(param_values)
 
     # Perform analysis
-    Si = sobol.analyze(problem, Y, print_to_console=True)
+    Si = analyze(problem, Y, print_to_console=True)
 
     # Print the first-order sensitivity indices
     print(Si['S1'])


### PR DESCRIPTION
This PR remove `from SALib.sample import saltelli` deprecated import statement
from Getting Started docs