### PR TITLE
Updated Numpy dependency to `>=2.0`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # required
-  - numpy>=1.20.3
+  - numpy>=2.0
   - pandas>=2.0
   - matplotlib>=3.5
   - scipy>=1.9.3


### PR DESCRIPTION
Updated Numpy dependency to `>=2.0` because of the issue described in #639 where SALib execution fails because support for `Numpy<2.0` has been dropped.

* Closes #639 

**Note:** this only fixes the dependency issue for Conda, not for PyPI

### Related PR:
* https://github.com/conda-forge/salib-feedstock/pull/41