### PR TITLE
Dead code in oakley2004.py

### DIFF
--- a/src/SALib/test_functions/oakley2004.py
+++ b/src/SALib/test_functions/oakley2004.py
@@ -23,8 +23,6 @@ def evaluate(X: np.ndarray, A: np.ndarray, M: np.ndarray) -> np.ndarray:
         x_i = X[i]
         Y[i] = a1 @ x_i + a2 @ np.sin(x_i) + a3 @ np.cos(x_i) + x_i.T @ (M @ x_i)
 
-        a3.T.dot(np.cos(X[0]))
-
     return Y
 
 


### PR DESCRIPTION
Removed the unnecessary computation of a3.T.dot(np.cos(X[0])) from the function.