### PR TITLE
Add support for Weibull distribution sampling

### DIFF
--- a/docs/user_guide/advanced.rst
+++ b/docs/user_guide/advanced.rst
@@ -116,6 +116,10 @@ parameter bounds but sample-specific metadata.
     e.g. :code:`[-3, 3, 0, 1]` indicates a lower bound of -3,
     upper bound of 3, mean 0 and standard deviation of 1.
 * lognorm: lognormal with ln-space mean and standard deviation
+* weibull: weibull distribution with shape, scale, and optional location parameters.
+    e.g. :code:`[1.5, 1.0, 5.0]` indicates a shape (k) of 1.5, scale (lambda) of 1.0, and a location of 5.0.
+    If only two values are provided, the location is assumed to be 0.
+    e.g. :code:`[1.5, 1.0]` assumes a location of 0.
 
 
 An example specification is shown below:


### PR DESCRIPTION
This PR adds native Weibull sampling support to SALib.

The implementation follows existing patterns and uses inverse transform sampling via `scipy.stats.weibull_min.ppf`, with basic parameter validation and documentation updates.

https://github.com/SALib/SALib/issues/669

#### Minimal example (after this commit)

```python
from SALib.sample.sobol import sample

problem = {
    'num_vars': 3,
    'names': ['param_unif', 'param_norm', 'param_weibull'],
    'bounds': [
        [10, 20],
        [100, 5],
        [1.5, 10, 1000]
    ],
    'dists': ['unif', 'norm', 'weibull']
}

N_SOBOL = 2**10
param_values = sample(problem, N_SOBOL)
```


This example demonstrates Weibull sampling using the new `dists="weibull"` option introduced in this PR.