### PR TITLE
Fix Sobol analysis for partially constant multi-output columns

### DIFF
--- a/src/SALib/analyze/sobol.py
+++ b/src/SALib/analyze/sobol.py
@@ -214,7 +214,7 @@ def first_order(A, AB, B):
     y = np.r_[A, B]
     if np.ptp(y) <= np.finfo(float).eps:
         warn(CONST_RESULT_MSG)
-        return np.zeros_like(np.var(y, axis=0), dtype=np.float64)
+        return np.zeros(y.shape[1:], dtype=np.float64)
 
     y_var = np.var(y, axis=0)
     return np.divide(
@@ -233,7 +233,7 @@ def total_order(A, AB, B):
     y = np.r_[A, B]
     if np.ptp(y) <= np.finfo(float).eps:
         warn(CONST_RESULT_MSG)
-        return np.zeros_like(np.var(y, axis=0), dtype=np.float64)
+        return np.zeros(y.shape[1:], dtype=np.float64)
 
     y_var = np.var(y, axis=0)
     return np.divide(
@@ -249,7 +249,7 @@ def second_order(A, ABj, ABk, BAj, B):
     y = np.r_[A, B]
     if np.ptp(y) <= np.finfo(float).eps:
         warn(CONST_RESULT_MSG)
-        return np.zeros_like(np.var(y, axis=0), dtype=np.float64)
+        return np.zeros(y.shape[1:], dtype=np.float64)
 
     Vjk = np.mean(BAj * ABk - A * B, axis=0) / np.var(y, axis=0)
     Sj = first_order(A, ABj, B)

--- a/src/SALib/analyze/sobol.py
+++ b/src/SALib/analyze/sobol.py
@@ -212,11 +212,17 @@ def first_order(A, AB, B):
     sample variance
     """
     y = np.r_[A, B]
-    if np.ptp(y) == 0:
+    if np.ptp(y) <= np.finfo(float).eps:
         warn(CONST_RESULT_MSG)
-        return np.float64(0.0)
+        return np.zeros_like(np.var(y, axis=0), dtype=np.float64)
 
-    return np.mean(B * (AB - A), axis=0) / np.var(y, axis=0)
+    y_var = np.var(y, axis=0)
+    return np.divide(
+        np.mean(B * (AB - A), axis=0),
+        y_var,
+        out=np.zeros_like(y_var, dtype=np.float64),
+        where=y_var > np.finfo(float).eps,
+    )
 
 
 def total_order(A, AB, B):
@@ -225,19 +231,25 @@ def total_order(A, AB, B):
     sample variance
     """
     y = np.r_[A, B]
-    if np.ptp(y) == 0:
+    if np.ptp(y) <= np.finfo(float).eps:
         warn(CONST_RESULT_MSG)
-        return np.float64(0.0)
+        return np.zeros_like(np.var(y, axis=0), dtype=np.float64)
 
-    return 0.5 * np.mean((A - AB) ** 2, axis=0) / np.var(y, axis=0)
+    y_var = np.var(y, axis=0)
+    return np.divide(
+        0.5 * np.mean((A - AB) ** 2, axis=0),
+        y_var,
+        out=np.zeros_like(y_var, dtype=np.float64),
+        where=y_var > np.finfo(float).eps,
+    )
 
 
 def second_order(A, ABj, ABk, BAj, B):
     """Second order estimator following Saltelli 2002"""
     y = np.r_[A, B]
-    if np.ptp(y) == 0:
+    if np.ptp(y) <= np.finfo(float).eps:
         warn(CONST_RESULT_MSG)
-        return np.float64(0.0)
+        return np.zeros_like(np.var(y, axis=0), dtype=np.float64)
 
     Vjk = np.mean(BAj * ABk - A * B, axis=0) / np.var(y, axis=0)
     Sj = first_order(A, ABj, B)

--- a/src/SALib/analyze/sobol.py
+++ b/src/SALib/analyze/sobol.py
@@ -251,7 +251,13 @@ def second_order(A, ABj, ABk, BAj, B):
         warn(CONST_RESULT_MSG)
         return np.zeros(y.shape[1:], dtype=np.float64)
 
-    Vjk = np.mean(BAj * ABk - A * B, axis=0) / np.var(y, axis=0)
+    y_var = np.var(y, axis=0)
+    Vjk = np.divide(
+        np.mean(BAj * ABk - A * B, axis=0),
+        y_var,
+        out=np.zeros_like(y_var, dtype=np.float64),
+        where=y_var > np.finfo(float).eps,
+    )
     Sj = first_order(A, ABj, B)
     Sk = first_order(A, ABk, B)
 

--- a/tests/test_sobol.py
+++ b/tests/test_sobol.py
@@ -256,3 +256,31 @@ def test_partial_constant_output():
     # Non-constant columns should have finite, non-trivial values
     assert np.all(np.isfinite(s1[1:])), f"S1 non-constant cols not finite: {s1}"
     assert np.all(np.isfinite(st[1:])), f"ST non-constant cols not finite: {st}"
+
+
+def test_partial_constant_output_second_order():
+    """second_order with some output columns constant, others varying."""
+    from SALib.analyze.sobol import second_order
+
+    rng = np.random.default_rng(42)
+    N = 10
+    D = 3
+    A = rng.random((N, D))
+    B = rng.random((N, D))
+    ABj = rng.random((N, D))
+    ABk = rng.random((N, D))
+    BAj = rng.random((N, D))
+
+    # column 0: strictly constant across all inputs
+    A[:, 0] = 0.5
+    B[:, 0] = 0.5
+    ABj[:, 0] = 0.5
+    ABk[:, 0] = 0.5
+    BAj[:, 0] = 0.5
+
+    s2 = second_order(A, ABj, ABk, BAj, B)
+
+    assert not np.any(np.isnan(s2)), f"S2 contains NaN: {s2}"
+    assert not np.any(np.isinf(s2)), f"S2 contains inf: {s2}"
+    assert s2[0] == 0.0, f"S2 constant col should be 0, got {s2[0]}"
+    assert np.all(np.isfinite(s2[1:])), f"S2 non-constant cols not finite: {s2}"

--- a/tests/test_sobol.py
+++ b/tests/test_sobol.py
@@ -1,6 +1,5 @@
 from pytest import raises, mark
 from numpy.testing import assert_equal, assert_allclose
-import warnings
 
 import numpy as np
 from scipy.stats import norm

--- a/tests/test_sobol.py
+++ b/tests/test_sobol.py
@@ -222,3 +222,27 @@ def test_grouped_constant_output():
     ), "Constant outputs should produce 0 total order sensitivity"
     assert np.all(Si["S1_conf"] == 0.0), "Constant outputs should produce 0 CI"
     assert np.all(Si["ST_conf"] == 0.0), "Constant outputs should produce 0 CI"
+
+
+def test_partial_constant_output():
+    """Sobol analysis with some output columns constant, others varying."""
+    from SALib.analyze.sobol import first_order, total_order
+
+    rng = np.random.default_rng(42)
+    N = 10
+    A = rng.random((N, 3))
+    B = rng.random((N, 3))
+    AB = rng.random((N, 3))
+
+    # column 0: strictly constant
+    A[:, 0] = 0.5
+    B[:, 0] = 0.5
+    AB[:, 0] = 0.5
+
+    s1 = first_order(A, AB, B)
+    st = total_order(A, AB, B)
+
+    assert not np.any(np.isnan(s1)), f"first_order produced NaN: {s1}"
+    assert not np.any(np.isnan(st)), f"total_order produced NaN: {st}"
+    assert s1[0] == 0.0, f"constant column S1 should be 0, got {s1[0]}"
+    assert st[0] == 0.0, f"constant column ST should be 0, got {st[0]}"

--- a/tests/test_sobol.py
+++ b/tests/test_sobol.py
@@ -1,5 +1,7 @@
 from pytest import raises, mark
 from numpy.testing import assert_equal, assert_allclose
+import warnings
+
 import numpy as np
 from scipy.stats import norm
 
@@ -225,14 +227,15 @@ def test_grouped_constant_output():
 
 
 def test_partial_constant_output():
-    """Sobol analysis with some output columns constant, others varying."""
+    """Sobol inner functions with some output columns constant, others varying."""
     from SALib.analyze.sobol import first_order, total_order
 
     rng = np.random.default_rng(42)
     N = 10
-    A = rng.random((N, 3))
-    B = rng.random((N, 3))
-    AB = rng.random((N, 3))
+    D = 3
+    A = rng.random((N, D))
+    B = rng.random((N, D))
+    AB = rng.random((N, D))
 
     # column 0: strictly constant
     A[:, 0] = 0.5
@@ -242,7 +245,15 @@ def test_partial_constant_output():
     s1 = first_order(A, AB, B)
     st = total_order(A, AB, B)
 
-    assert not np.any(np.isnan(s1)), f"first_order produced NaN: {s1}"
-    assert not np.any(np.isnan(st)), f"total_order produced NaN: {st}"
-    assert s1[0] == 0.0, f"constant column S1 should be 0, got {s1[0]}"
-    assert st[0] == 0.0, f"constant column ST should be 0, got {st[0]}"
+    # No NaN or inf
+    for name, arr in [("S1", s1), ("ST", st)]:
+        assert not np.any(np.isnan(arr)), f"{name} contains NaN: {arr}"
+        assert not np.any(np.isinf(arr)), f"{name} contains inf: {arr}"
+
+    # Constant column returns zero
+    assert s1[0] == 0.0, f"S1 constant col should be 0, got {s1[0]}"
+    assert st[0] == 0.0, f"ST constant col should be 0, got {st[0]}"
+
+    # Non-constant columns should have finite, non-trivial values
+    assert np.all(np.isfinite(s1[1:])), f"S1 non-constant cols not finite: {s1}"
+    assert np.all(np.isfinite(st[1:])), f"ST non-constant cols not finite: {st}"


### PR DESCRIPTION
Fixes #619.

For multi-output analysis, the previous scalar `np.ptp(y)` check could miss constant output columns and produce invalid Sobol indices. This applies per-column zero-variance handling and adds regression coverage for mixed constant and varying outputs.