### PR TITLE
Fix first-order enhanced HDMR total sensitivity

### DIFF
--- a/src/SALib/analyze/enhanced_hdmr.py
+++ b/src/SALib/analyze/enhanced_hdmr.py
@@ -1436,7 +1436,7 @@ def _finalize(hdmr, Si, alpha, return_emulator):
     # Compute the total sensitivity of each parameter/coefficient
     for r in range(hdmr.d):
         if hdmr.max_order == 1:
-            TS = hdmr.S[r, :]
+            TS = Si["S"][r, :]
         elif hdmr.max_order == 2:
             ij = hdmr.d + np.where(np.sum(hdmr.beta == r, axis=1) == 1)[0]
             TS = np.sum(Si["S"][np.append(r, ij), :], axis=0)

--- a/tests/test_hdmr.py
+++ b/tests/test_hdmr.py
@@ -1,9 +1,10 @@
 from __future__ import division
 
+import numpy as np
 import pytest
 from pytest import raises
 
-from SALib.analyze import hdmr
+from SALib.analyze import enhanced_hdmr, hdmr
 from SALib.sample import latin
 from SALib.test_functions import Ishigami, linear_model_1
 from SALib.util import read_param_file
@@ -81,3 +82,28 @@ def test_dim_mismatch():
     Y = linear_model_1.evaluate(X)
     with raises(RuntimeError):
         hdmr.analyze(problem, X, Y[:-2])
+
+
+def test_enhanced_hdmr_first_order_total_sensitivity():
+    rng = np.random.default_rng(101)
+    X = rng.random((300, 3))
+    Y = X @ np.array([1.0, -2.0, 0.5])
+    problem = {
+        "num_vars": 3,
+        "names": ["x1", "x2", "x3"],
+        "bounds": [[0, 1]] * 3,
+    }
+    result = enhanced_hdmr.analyze(
+        problem,
+        X,
+        Y,
+        max_order=1,
+        poly_order=1,
+        bootstrap=2,
+        subset=300,
+        max_iter=100,
+        extended_base=False,
+        seed=101,
+    )
+
+    np.testing.assert_allclose(result["ST"], result["S"])


### PR DESCRIPTION
Fixes #642.

## Summary

`enhanced_hdmr._finalize` read first-order bootstrap sensitivities from `hdmr.S`, but `CoreParams` has no `S` field. The values are stored in `Si["S"]`, which the higher-order branches already use.

## Changes

- Read the `max_order=1` total-sensitivity samples from `Si["S"]`.
- Add a deterministic public-API regression that verifies first-order total sensitivities equal the corresponding first-order sensitivities.

## Testing

- RED on the exact upstream base: `AttributeError: 'CoreParams' object has no attribute 'S'`
- Focused regression: `1 passed`
- HDMR and regression files: `28 passed`
- Full repository suite: `207 passed, 1 xfailed`
- Official pre-commit hooks (including Black 24.2.0 and Ruff 0.3.0): passed
- `git diff --check`: passed

## AI-use disclosure

This pull request was prepared and opened by OpenAI Codex acting as an automated contributor under the account owner's authorization. Codex rechecked the issue, repository policy, and duplicate state; simplified the retained regression to avoid private monkeypatching; and ran the validation listed above. The production change is limited to the single incorrect array-source lookup.
