### PR TITLE
Fix third-order enhanced HDMR term indexing

### DIFF
--- a/src/SALib/analyze/enhanced_hdmr.py
+++ b/src/SALib/analyze/enhanced_hdmr.py
@@ -1442,7 +1442,7 @@ def _finalize(hdmr, Si, alpha, return_emulator):
             TS = np.sum(Si["S"][np.append(r, ij), :], axis=0)
         elif hdmr.max_order == 3:
             ij = hdmr.d + np.where(np.sum(hdmr.beta == r, axis=1) == 1)[0]
-            ijk = hdmr.d + hdmr.nc2 + np.where(np.sum(hdmr.nc3 == r, axis=1) == 1)[0]
+            ijk = hdmr.d + hdmr.nc2 + np.where(np.sum(hdmr.gamma == r, axis=1) == 1)[0]
             TS = np.sum(Si["S"][np.append(r, np.append(ij, ijk)), :], axis=0)
         Si["ST"][r] = np.mean(TS)
         Si["ST_conf"][r] = mult * np.std(TS)

--- a/tests/test_hdmr.py
+++ b/tests/test_hdmr.py
@@ -1,12 +1,52 @@
 from __future__ import division
 
+from itertools import combinations
+
+import numpy as np
 import pytest
 from pytest import raises
 
-from SALib.analyze import hdmr
+from SALib.analyze import enhanced_hdmr, hdmr
 from SALib.sample import latin
 from SALib.test_functions import Ishigami, linear_model_1
 from SALib.util import read_param_file
+
+
+def test_enhanced_hdmr_third_order_terms():
+    names = ["x1", "x2", "x3", "x4"]
+    rng = np.random.default_rng(667)
+    X = rng.uniform(-1, 1, size=(300, len(names)))
+    Y = X[:, 0] + X[:, 1] * X[:, 2] + X[:, 0] * X[:, 2] * X[:, 3]
+
+    hdmr, _ = enhanced_hdmr._core_params(
+        {"names": names.copy()}, len(X), len(names), np.mean(Y), 1, 3, 1, len(X), True
+    )
+    assert np.isscalar(hdmr.nc3)
+    assert hdmr.gamma.shape == (len(list(combinations(names, 3))), 3)
+
+    for max_order in (2, 3):
+        expected_terms = names.copy()
+        for order in range(2, max_order + 1):
+            expected_terms.extend("/".join(term) for term in combinations(names, order))
+
+        result = enhanced_hdmr.analyze(
+            {"num_vars": len(names), "names": names.copy()},
+            X,
+            Y,
+            max_order=max_order,
+            poly_order=1,
+            bootstrap=1,
+            seed=667,
+        )
+
+        assert result["Term"] == expected_terms
+        for key in ("S", "Sa", "Sb", "Signf", "S_conf", "Sa_conf", "Sb_conf"):
+            assert result[key].shape == (len(expected_terms),)
+            assert np.isfinite(result[key]).all()
+        assert result["ST"].shape == (len(expected_terms),)
+        assert result["ST_conf"].shape == (len(expected_terms),)
+        assert np.isfinite(result["ST"][: len(names)]).all()
+        assert np.isfinite(result["ST_conf"][: len(names)]).all()
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")


### PR DESCRIPTION
## Summary

- use the third-order combination matrix (`gamma`) when collecting enhanced HDMR total-order terms
- add a deterministic regression test for second- and third-order term layouts and finite results

Fixes #667.

## Root cause

`nc3` is the scalar count of third-order combinations, while `gamma` is the `(C(d, 3), 3)` matrix that records which variables belong to each third-order term. `_finalize` attempted a two-dimensional reduction over `nc3`, which raised `AxisError` for `max_order=3`.

This is independent of #679: that draft addresses the separate `max_order=1` path, while this change fixes third-order term indexing.

## Validation

- fresh in-memory check on upstream `1c375488e1c85167929142fb54166eb35e4f99f6`: reproduced the `AxisError` before the patch and obtained finite total-order values after it
- archived exact-commit evidence, reverified against a 57-file SHA-256/byte manifest:
  - focused regression: `1 passed`
  - `tests/test_hdmr.py`: `9 passed`
  - full suite: `207 passed, 1 xfailed`
- `git diff --check`

No dependencies were added.

## AI disclosure

This draft pull request was prepared by OpenAI Codex operating for @sapunyangkut. Codex reproduced the reported failure, applied the minimal source fix, added the regression test, and rechecked the evidence and repository contribution gates.
