### PR TITLE
Seed the delta SVM regression test

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -494,7 +494,8 @@ def test_regression_delta():
     assert_allclose(Si["S1"], [0.31, 0.44, 0.00], atol=5e-2, rtol=1e-1)
 
 
-def test_regression_delta_svm():
+def test_regression_delta_svm(set_seed):
+    # bias_reduced_delta bootstraps using NumPy's legacy global RNG.
     xy_input_fn = "tests/data/delta_svm_regression_data.csv"
     inputs = np.loadtxt(xy_input_fn, delimiter=",", skiprows=1)
 


### PR DESCRIPTION
Closes #687.

Request the existing `set_seed` fixture in `test_regression_delta_svm`. The raw bootstrap in `delta.bias_reduced_delta` uses NumPy's legacy global RNG, so the unseeded test depended on random draws consumed by preceding tests.

This changes only the test's fixture dependency and adds an explanatory comment. The fixture's existing seed (123456), estimator, bootstrap count, expected values, and tolerances are unchanged. It is separate from the discrepancy-sampler fix in #685.

Validation on the current `main` base (`aa2c554`):

- Python 3.10.20 / NumPy 2.2.6 / SciPy 1.15.3: 17 targeted tests passed.
- Python 3.14.6 / NumPy 2.4.3 / SciPy 1.17.1: the same 17 tests passed.
- Applying the fixture after two different ambient seeds produced identical estimates in the Python 3.14 environment.
- Black 24.2.0, Ruff 0.3.0, and `git diff --check` passed.

```sh
python -m pytest -q tests/test_analyze_delta.py tests/test_regression.py::test_regression_delta_svm
```

These are targeted local checks, not a full-suite or cross-platform CI pass.
